### PR TITLE
Fix language display

### DIFF
--- a/src/client/app/actions/monaco.ts
+++ b/src/client/app/actions/monaco.ts
@@ -27,7 +27,7 @@ export class MonacoActionTypes {
 export class ChangeTabAction implements Action {
     readonly type = MonacoActionTypes.CHANGE_TAB;
 
-    constructor(public payload: { type: string, language: string }) {}
+    constructor(public payload: { name: string, language: string }) {}
 }
 
 export class ResetAction implements Action {

--- a/src/client/app/actions/monaco.ts
+++ b/src/client/app/actions/monaco.ts
@@ -27,7 +27,7 @@ export class MonacoActionTypes {
 export class ChangeTabAction implements Action {
     readonly type = MonacoActionTypes.CHANGE_TAB;
 
-    constructor(public payload: string, public language: string) { }
+    constructor(public payload: { type: string, language: string }) {}
 }
 
 export class ResetAction implements Action {
@@ -39,13 +39,13 @@ export class ResetAction implements Action {
 export class UpdateIntellisenseAction implements Action {
     readonly type = MonacoActionTypes.UPDATE_INTELLISENSE;
 
-    constructor(public payload: string[], public language: string) { }
+    constructor(public payload: { libraries: string[], language: string }) {}
 }
 
 export class AddIntellisenseAction implements Action {
     readonly type = MonacoActionTypes.ADD_INTELLISENSE;
 
-    constructor(public payload: string, public language: string) { }
+    constructor(public payload: { url: string, language: string }) { }
 }
 
 export class UpdateIntellisenseSuccessAction implements Action {

--- a/src/client/app/containers/editor.ts
+++ b/src/client/app/containers/editor.ts
@@ -43,14 +43,23 @@ export class Editor implements AfterViewInit {
         this._subscribeToState();
     }
 
-    changeTab = (name: string = 'script') => this._store.dispatch(new Monaco.ChangeTabAction(name, this.tabs.get(name).language));
+    changeTab = (type: string = 'script') => {
+        let language = '';
+        if (type !== 'libraries') {
+            language = this.tabs.get(type).language;
+        }
+
+        this._store.dispatch(new Monaco.ChangeTabAction({ type: type, language }));
+    }
 
     updateIntellisense() {
         if (this.snippet == null) {
             return;
         }
 
-        this._store.dispatch(new Monaco.UpdateIntellisenseAction(this.snippet.libraries.split('\n'), 'typescript'));
+        this._store.dispatch(new Monaco.UpdateIntellisenseAction(
+            { libraries: this.snippet.libraries.split('\n'), language: 'typescript' }
+        ));
     }
 
     private _createTabs() {

--- a/src/client/app/containers/editor.ts
+++ b/src/client/app/containers/editor.ts
@@ -43,13 +43,13 @@ export class Editor implements AfterViewInit {
         this._subscribeToState();
     }
 
-    changeTab = (type: string = 'script') => {
+    changeTab = (name: string = 'script') => {
         let language = '';
-        if (type !== 'libraries') {
-            language = this.tabs.get(type).language;
+        if (name !== 'libraries') {
+            language = this.tabs.get(name).language;
         }
 
-        this._store.dispatch(new Monaco.ChangeTabAction({ type: type, language }));
+        this._store.dispatch(new Monaco.ChangeTabAction({ name: name, language }));
     }
 
     updateIntellisense() {

--- a/src/client/app/reducers/monaco.ts
+++ b/src/client/app/reducers/monaco.ts
@@ -17,8 +17,8 @@ export function reducer(state = initialState, action: MonacoActions): MonacoStat
         case MonacoActionTypes.CHANGE_TAB:
             return {
                 ...state,
-                activeTab: action.payload,
-                activeLanguage: action.language
+                activeTab: action.payload.type,
+                activeLanguage: action.payload.language
             };
 
         case MonacoActionTypes.RESET:

--- a/src/client/app/reducers/monaco.ts
+++ b/src/client/app/reducers/monaco.ts
@@ -17,7 +17,7 @@ export function reducer(state = initialState, action: MonacoActions): MonacoStat
         case MonacoActionTypes.CHANGE_TAB:
             return {
                 ...state,
-                activeTab: action.payload.type,
+                activeTab: action.payload.name,
                 activeLanguage: action.payload.language
             };
 


### PR DESCRIPTION
Hook up language display at bottom of editor

Today, language display was always empty (null).  Looks like the issues is that the language-related actions were taking two parameters rather than just the single payload parameter.  Fixed by unifying payload to accept complex objects like

{ type, language }