### PR TITLE
Small UI changes for Gists

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,7 @@
 # Manual-testing scenarios
 
 * Create a snippet -- both "new" and from a sample
+  * There should be no URL field when viewing the snippet's information
 * Import someone else's snippet
   * From YAML
   * From Gist (incl. old-style)

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,7 +1,7 @@
 # Manual-testing scenarios
 
 * Create a snippet -- both "new" and from a sample
-  * There should be no URL field when viewing the snippet's information
+  * There should be no Gist URL field when viewing the snippet's information
 * Import someone else's snippet
   * From YAML
   * From Gist (incl. old-style)
@@ -19,7 +19,9 @@
 * Sharing:
   * Copying to clipboard works
   * Can share as gist, public and private
+    * Gist URL should be updated in snippet information
   * Can update existing gist
   * Update option should not appear in share menu after importing a gist that you do not own
   * Update option appears in share menu after initial publish of a new gist or a gist that you did not previously own
   * Deleting a gist and then trying to update it via local copy should prompt full refresh
+  

--- a/src/client/app/components/snippet.info.ts
+++ b/src/client/app/components/snippet.info.ts
@@ -19,8 +19,8 @@ import { isNil } from 'lodash';
                 </div>
 
                 <div *ngIf="!!url" class="ms-TextField">
-                    <label class="ms-Label">${Strings.urlLabel}</label>
-                    <input class="ms-TextField-field" type="text" [(ngModel)]="url" placeholder="" disabled />
+                    <label class="ms-Label">${Strings.gistUrlLabel}</label>
+                    <a href="{{url}}" target="_blank">Open in browser</a>
                 </div>
             </div>
             <div class="ms-Dialog-actions">

--- a/src/client/app/components/snippet.info.ts
+++ b/src/client/app/components/snippet.info.ts
@@ -16,6 +16,11 @@ import { Strings } from '../helpers';
                     <label class="ms-Label">${Strings.descriptionLabel}</label>
                     <textarea class="ms-TextField-field ms-font-m" [(ngModel)]="snippet.description" placeholder="Description of the snippet"></textarea>
                 </div>
+
+                <div *ngIf="url" class="ms-TextField ms-TextField--multiline">
+                    <label class="ms-Label">${Strings.urlLabel}</label>
+                    <textarea class="ms-TextField-field ms-font-m" [(ngModel)]="url" disabled="true"></textarea>
+                </div>
             </div>
             <div class="ms-Dialog-actions">
                 <div class="ms-Dialog-actionsRight">
@@ -35,4 +40,11 @@ export class SnippetInfo {
     @Input() snippet: ISnippet;
     @Input() show: boolean;
     @Output() dismiss = new EventEmitter<ISnippet>();
+
+    get url() {
+        if (!this.snippet.gist) {
+            return null;
+        }
+        return `https://gist.github.com/${this.snippet.gist}`;
+    }
 }

--- a/src/client/app/components/snippet.info.ts
+++ b/src/client/app/components/snippet.info.ts
@@ -1,5 +1,6 @@
 import { Component, Input, ChangeDetectionStrategy, Output, EventEmitter } from '@angular/core';
 import { Strings } from '../helpers';
+import { isNil } from 'lodash';
 
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -42,9 +43,6 @@ export class SnippetInfo {
     @Output() dismiss = new EventEmitter<ISnippet>();
 
     get url() {
-        if (!this.snippet.gist) {
-            return null;
-        }
-        return `https://gist.github.com/${this.snippet.gist}`;
+        return isNil(this.snippet.gist) ? null : `https://gist.github.com/${this.snippet.gist}`;
     }
 }

--- a/src/client/app/components/snippet.info.ts
+++ b/src/client/app/components/snippet.info.ts
@@ -18,9 +18,9 @@ import { isNil } from 'lodash';
                     <textarea class="ms-TextField-field ms-font-m" [(ngModel)]="snippet.description" placeholder="Description of the snippet"></textarea>
                 </div>
 
-                <div *ngIf="url" class="ms-TextField ms-TextField--multiline">
+                <div *ngIf="!!url" class="ms-TextField">
                     <label class="ms-Label">${Strings.urlLabel}</label>
-                    <textarea class="ms-TextField-field ms-font-m" [(ngModel)]="url" disabled="true"></textarea>
+                    <input class="ms-TextField-field" type="text" [(ngModel)]="url" placeholder="" disabled />
                 </div>
             </div>
             <div class="ms-Dialog-actions">

--- a/src/client/app/components/snippet.info.ts
+++ b/src/client/app/components/snippet.info.ts
@@ -20,7 +20,7 @@ import { isNil } from 'lodash';
 
                 <div *ngIf="!!url" class="ms-TextField">
                     <label class="ms-Label">${Strings.gistUrlLabel}</label>
-                    <a href="{{url}}" target="_blank">Open in browser</a>
+                    <a href="{{url}}" target="_blank">${Strings.gistUrlLinkLabel}</a>
                 </div>
             </div>
             <div class="ms-Dialog-actions">

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -176,21 +176,21 @@ export class AppComponent {
                 }
                 else if (isPublic) {
                     this._effects.alert(Strings.sharePublicSnippetConfirm, `${Strings.share} ${this.snippet.name}`, Strings.share, Strings.cancelButtonLabel)
-                    .then((result: string) => {
-                            if (result !== Strings.cancelButtonLabel) {
-                                this._store.dispatch(new GitHub.SharePublicGistAction(this.snippet));
+                        .then((result: string) => {
+                                if (result !== Strings.cancelButtonLabel) {
+                                    this._store.dispatch(new GitHub.SharePublicGistAction(this.snippet));
+                                }
                             }
-                        }
-                    );
+                        );
                 }
                 else {
                     this._effects.alert(Strings.sharePrivateSnippetConfirm, `${Strings.share} ${this.snippet.name}`, Strings.share, Strings.cancelButtonLabel)
-                    .then((result: string) => {
-                            if (result !== Strings.cancelButtonLabel) {
-                                this._store.dispatch(new GitHub.SharePrivateGistAction(this.snippet));
+                        .then((result: string) => {
+                                if (result !== Strings.cancelButtonLabel) {
+                                    this._store.dispatch(new GitHub.SharePrivateGistAction(this.snippet));
+                                }
                             }
-                        }
-                    );
+                        );
                 }
 
                 if (sub && !sub.closed) {

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -175,10 +175,26 @@ export class AppComponent {
                     this._store.dispatch(new GitHub.UpdateGistAction(this.snippet));
                 }
                 else if (isPublic) {
-                    this._store.dispatch(new GitHub.SharePublicGistAction(this.snippet));
+                    let sharePublicGist = async() => {
+                        let result = await this._effects.alert(Strings.sharePublicSnippetConfirm, `${Strings.share} ${this.snippet.name}`, `${Strings.share}`, `${Strings.cancelButtonLabel}`);
+                        return result;
+                    };
+                    sharePublicGist().then((result: string) => {
+                        if (result !== Strings.cancelButtonLabel) {
+                            this._store.dispatch(new GitHub.SharePublicGistAction(this.snippet));
+                        }
+                    });
                 }
                 else {
-                    this._store.dispatch(new GitHub.SharePrivateGistAction(this.snippet));
+                    let sharePrivateGist = async() => {
+                        let result = await this._effects.alert(Strings.sharePrivateSnippetConfirm, `${Strings.share} ${this.snippet.name}`, `${Strings.share}`, `${Strings.cancelButtonLabel}`);
+                        return result;
+                    };
+                    sharePrivateGist().then((result: string) => {
+                        if (result !== Strings.cancelButtonLabel) {
+                            this._store.dispatch(new GitHub.SharePrivateGistAction(this.snippet));
+                        }
+                    });
                 }
 
                 if (sub && !sub.closed) {

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -175,10 +175,7 @@ export class AppComponent {
                     this._store.dispatch(new GitHub.UpdateGistAction(this.snippet));
                 }
                 else if (isPublic) {
-                    let sharePublicGist = async() => {
-                        let result = await this._effects.alert(Strings.sharePublicSnippetConfirm, `${Strings.share} ${this.snippet.name}`, `${Strings.share}`, `${Strings.cancelButtonLabel}`);
-                        return result;
-                    };
+                    let sharePublicGist = () => (this._effects.alert(Strings.sharePublicSnippetConfirm, `${Strings.share} ${this.snippet.name}`, Strings.share, Strings.cancelButtonLabel));
                     sharePublicGist().then((result: string) => {
                         if (result !== Strings.cancelButtonLabel) {
                             this._store.dispatch(new GitHub.SharePublicGistAction(this.snippet));
@@ -186,10 +183,7 @@ export class AppComponent {
                     });
                 }
                 else {
-                    let sharePrivateGist = async() => {
-                        let result = await this._effects.alert(Strings.sharePrivateSnippetConfirm, `${Strings.share} ${this.snippet.name}`, `${Strings.share}`, `${Strings.cancelButtonLabel}`);
-                        return result;
-                    };
+                    let sharePrivateGist = () => (this._effects.alert(Strings.sharePrivateSnippetConfirm, `${Strings.share} ${this.snippet.name}`, Strings.share, Strings.cancelButtonLabel));
                     sharePrivateGist().then((result: string) => {
                         if (result !== Strings.cancelButtonLabel) {
                             this._store.dispatch(new GitHub.SharePrivateGistAction(this.snippet));

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -175,20 +175,22 @@ export class AppComponent {
                     this._store.dispatch(new GitHub.UpdateGistAction(this.snippet));
                 }
                 else if (isPublic) {
-                    let sharePublicGist = () => (this._effects.alert(Strings.sharePublicSnippetConfirm, `${Strings.share} ${this.snippet.name}`, Strings.share, Strings.cancelButtonLabel));
-                    sharePublicGist().then((result: string) => {
-                        if (result !== Strings.cancelButtonLabel) {
-                            this._store.dispatch(new GitHub.SharePublicGistAction(this.snippet));
+                    this._effects.alert(Strings.sharePublicSnippetConfirm, `${Strings.share} ${this.snippet.name}`, Strings.share, Strings.cancelButtonLabel)
+                    .then((result: string) => {
+                            if (result !== Strings.cancelButtonLabel) {
+                                this._store.dispatch(new GitHub.SharePublicGistAction(this.snippet));
+                            }
                         }
-                    });
+                    );
                 }
                 else {
-                    let sharePrivateGist = () => (this._effects.alert(Strings.sharePrivateSnippetConfirm, `${Strings.share} ${this.snippet.name}`, Strings.share, Strings.cancelButtonLabel));
-                    sharePrivateGist().then((result: string) => {
-                        if (result !== Strings.cancelButtonLabel) {
-                            this._store.dispatch(new GitHub.SharePrivateGistAction(this.snippet));
+                    this._effects.alert(Strings.sharePrivateSnippetConfirm, `${Strings.share} ${this.snippet.name}`, Strings.share, Strings.cancelButtonLabel)
+                    .then((result: string) => {
+                            if (result !== Strings.cancelButtonLabel) {
+                                this._store.dispatch(new GitHub.SharePrivateGistAction(this.snippet));
+                            }
                         }
-                    });
+                    );
                 }
 
                 if (sub && !sub.closed) {

--- a/src/client/app/helpers/strings.ts
+++ b/src/client/app/helpers/strings.ts
@@ -81,6 +81,8 @@ export class Strings {
     //snippet.info.ts
     static readonly nameLabel = 'Name';
     static readonly descriptionLabel = 'Description';
+
+    /** NEEDS STRING REVIEW */
     static readonly urlLabel = 'Gist URL';
 
     // Containers strings

--- a/src/client/app/helpers/strings.ts
+++ b/src/client/app/helpers/strings.ts
@@ -81,6 +81,7 @@ export class Strings {
     //snippet.info.ts
     static readonly nameLabel = 'Name';
     static readonly descriptionLabel = 'Description';
+    static readonly urlLabel = 'Gist URL';
 
     // Containers strings
     //app.ts
@@ -99,6 +100,8 @@ export class Strings {
     static readonly darkTheme = 'Dark';
 
     static readonly deleteSnippetConfirm = 'Are you sure you want to delete this snippet?';
+    static readonly sharePublicSnippetConfirm = 'Are you sure you want to share this snippet as a new public gist?';
+    static readonly sharePrivateSnippetConfirm = 'Are you sure you want to share this snippet as a new secret gist?';
 
     static readonly tabDisplayNames = {
         'script': 'Script',

--- a/src/client/app/helpers/strings.ts
+++ b/src/client/app/helpers/strings.ts
@@ -84,6 +84,7 @@ export class Strings {
 
     /** NEEDS STRING REVIEW */
     static readonly gistUrlLabel = 'Gist URL';
+    static readonly gistUrlLinkLabel = 'Open in browser';
 
     // Containers strings
     //app.ts

--- a/src/client/app/helpers/strings.ts
+++ b/src/client/app/helpers/strings.ts
@@ -83,7 +83,7 @@ export class Strings {
     static readonly descriptionLabel = 'Description';
 
     /** NEEDS STRING REVIEW */
-    static readonly urlLabel = 'Gist URL';
+    static readonly gistUrlLabel = 'Gist URL';
 
     // Containers strings
     //app.ts

--- a/src/client/app/helpers/strings.ts
+++ b/src/client/app/helpers/strings.ts
@@ -102,6 +102,8 @@ export class Strings {
     static readonly darkTheme = 'Dark';
 
     static readonly deleteSnippetConfirm = 'Are you sure you want to delete this snippet?';
+
+    /** NEEDS STRING REVIEW */
     static readonly sharePublicSnippetConfirm = 'Are you sure you want to share this snippet as a new public gist?';
     static readonly sharePrivateSnippetConfirm = 'Are you sure you want to share this snippet as a new secret gist?';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added 'Gist URL' field to snippet info box, also added confirmation boxes for sharing public and private gists

## Description
<!--- Describe your changes in detail -->

In snippet info box, accessed by clicking on the snippet's name, there is now a 'Gist URL' field, in addition to the preexisting 'Name' and 'Description' fields. This field is only populated if the Gist has been imported or has already been shared: the URL displayed is its GitHub URL and is grayed out and cannot be modified. For newly created/non-shared snippets, this field will not show.

Added confirmation boxes for sharing public and private gists. Now user will be prompted before sharing snippet as gist.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Designed to aid users with gist workflow: can now see Gist URLs (if they exist), which helps them make sure they're working on correct gist. And prompting before sharing ensures that users understand they are creating a new copy of theirs gist.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing has been done by the updated changes in `TESTING.md`.

## Screenshots (if appropriate):

Screenshots of changes follow:

Sharing Gist confirmation:

![capture](https://user-images.githubusercontent.com/14340560/27550143-70997396-5a53-11e7-9fad-961af5469c67.PNG)

Gist URL in snippet info:

![capture](https://user-images.githubusercontent.com/14340560/27604478-394fd764-5b2e-11e7-8421-bcb82e0652e2.PNG)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
