### PR TITLE
Add to update feature: existing snippets with gist ids are assumed to be updateable until update request fails

### DIFF
--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -73,12 +73,11 @@ export class AppComponent {
         return this.profile$
             .filter(profile => profile != null)
             .map(profile => {
-                if (!isNil(this.snippet.gistOwnerId)) {
-                    return this.snippet.gistOwnerId === profile.login;
+                if (!isNil(this.snippet.gist)) {
+                    return !isNil(this.snippet.gistOwnerId) ? this.snippet.gistOwnerId === profile.login : true;
                 }
                 return false;
-            }
-            );
+            });
     }
 
     menuOpened$ = this._store.select(fromRoot.getMenu);

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -5,7 +5,7 @@ import { UI, Snippet, GitHub } from '../actions';
 import { UIEffects } from '../effects/ui';
 import { environment, isOfficeHost, isInsideOfficeApp } from '../helpers';
 import { Strings } from '../strings';
-import { isNil } from 'lodash';
+import { isEmpty } from 'lodash';
 
 @Component({
     selector: 'app',
@@ -73,12 +73,12 @@ export class AppComponent {
         return this.profile$
             .filter(profile => profile != null)
             .map(profile => {
-                if (isNil(this.snippet.gist)) {
+                if (isEmpty(this.snippet.gist)) {
                     return false;
                 }
 
                 // Assume that user owns gist, for back-compat
-                return isNil(this.snippet.gistOwnerId) ? true : this.snippet.gistOwnerId === profile.login;
+                return isEmpty(this.snippet.gistOwnerId) ? true : this.snippet.gistOwnerId === profile.login;
             });
     }
 

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -73,10 +73,12 @@ export class AppComponent {
         return this.profile$
             .filter(profile => profile != null)
             .map(profile => {
-                if (!isNil(this.snippet.gist)) {
-                    return !isNil(this.snippet.gistOwnerId) ? this.snippet.gistOwnerId === profile.login : true;
+                if (isNil(this.snippet.gist)) {
+                    return false;
                 }
-                return false;
+
+                // Assume that user owns gist, for back-compat
+                return isNil(this.snippet.gistOwnerId) ? true : this.snippet.gistOwnerId === profile.login;
             });
     }
 

--- a/src/client/app/services/github.service.ts
+++ b/src/client/app/services/github.service.ts
@@ -96,7 +96,7 @@ export class GitHubService {
             return Observable.of([]);
         }
         let url = `${this._baseUrl}/users/${this.profile.login}/gists`;
-        return this._request.get<IGist[]>(url, ResponseTypes.JSON, this._headers, true /*use cache*/);
+        return this._request.get<IGist[]>(url, ResponseTypes.JSON, this._headers, true /*force bypass of cache*/);
     }
 
     gist(id: string, sha?: string): Observable<IGist> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Existing snippets in users' local storage, if they were imported from GitHub, have gist IDs associated with them, but they do not have the new `gistOwnerId` field added in the update feature. As a result users will currently not see the 'Update' option.

This pull request optimistically assumes that previously imported gists are owned by the user, so the user will now see the 'Update' option. If the user tries to update the gist and fails, then the gist may not exist anymore or the user may not own it: the program looks for this error code and then sets `gistOwnerId` so that the user no longer sees the 'Update' option.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Previously imported gists should be able to be updated, but right now that's not possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Has been tested via the different 'Update' scenarios in `TESTING.md`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
