### PR TITLE
Fix menu hide issue

### DIFF
--- a/src/client/app/components/about.ts
+++ b/src/client/app/components/about.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy, Output, EventEmitter, AfterViewInit, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy, Output, EventEmitter, AfterViewInit } from '@angular/core';
 import { environment, storageSize, storage } from '../helpers';
 import {Strings, getAvailableLanguages, getDisplayLanguage, setDisplayLanguage } from '../strings';
 import { UIEffects } from '../effects/ui';
@@ -70,8 +70,7 @@ export class About implements AfterViewInit {
     selectedConfig = '';
 
     constructor(
-        private _effects: UIEffects,
-        private _changeDetector: ChangeDetectorRef
+        private _effects: UIEffects
     ) {}
 
     ngAfterViewInit() {
@@ -112,7 +111,6 @@ export class About implements AfterViewInit {
         );
         if (changeEnvironmentResult === this.strings.cancelButtonLabel) {
             this.selectedConfig = this.configs.find(c => c.value === currentConfigName).value;
-            this._changeDetector.detectChanges();
             return;
         }
 

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -19,7 +19,7 @@ import { isEmpty } from 'lodash';
                     <command icon="Play" title="{{strings.runInThisPane}}" [async]="running$|async" (click)="run()"></command>
                     <command icon="OpenPaneMirrored" title="{{strings.runSideBySide}}" (click)="runSideBySide()"></command>
                 </command>
-                <command [hidden]="isEmpty" icon="Share" [async]="sharing$|async" title="{{strings.share}}">
+                <command [ngClass]="{'disabled': isDisabled}" [hidden]="isEmpty" icon="Share" [async]="sharing$|async" title="{{strings.share}}">
                     <command *ngIf="isGistOwned|async" icon="Save" title="{{strings.updateMenu}}" (click)="shareGist({isPublic: false, isUpdate: true})"></command>
                     <command icon="PageCheckedin" title="{{strings.shareMenuPublic}}" (click)="shareGist({isPublic: true, isUpdate: false})"></command>
                     <command icon="ProtectedDocument" title="{{strings.shareMenuPrivate}}" (click)="shareGist({isPublic: false, isUpdate: false})"></command>
@@ -50,16 +50,21 @@ import { isEmpty } from 'lodash';
 export class AppComponent {
     snippet: ISnippet;
     isEmpty: boolean;
+    isDisabled: boolean;
 
     strings = Strings();
 
     constructor(
         private _store: Store<fromRoot.State>,
-        private _effects: UIEffects
+        private _effects: UIEffects,
     ) {
         this._store.select(fromRoot.getCurrent).subscribe(snippet => {
             this.isEmpty = snippet == null;
             this.snippet = snippet;
+        });
+
+        this._store.select(fromRoot.getSharing).subscribe(sharing => {
+            sharing ? this.isDisabled = true : this.isDisabled = false;
         });
 
         this._store.dispatch(new GitHub.IsLoggedInAction());
@@ -187,6 +192,8 @@ export class AppComponent {
 
                 let { isPublic, isUpdate } = values;
                 let confirmationAlertIfAny = null;
+                this.isDisabled = true;
+
                 if (isUpdate) {
                     this._store.dispatch(new GitHub.UpdateGistAction(this.snippet));
                 }
@@ -198,6 +205,8 @@ export class AppComponent {
                     if (confirmationAlertIfAny !== this.strings.cancelButtonLabel) {
                         this._store.dispatch(new GitHub.SharePublicGistAction(this.snippet));
                     }
+
+                    this.isDisabled = false;
                 }
                 else {
                     if (this.snippet.gist) {
@@ -207,6 +216,8 @@ export class AppComponent {
                     if (confirmationAlertIfAny !== this.strings.cancelButtonLabel) {
                         this._store.dispatch(new GitHub.SharePrivateGistAction(this.snippet));
                     }
+
+                    this.isDisabled = false;
                 }
 
                 if (sub && !sub.closed) {

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -56,7 +56,7 @@ export class AppComponent {
 
     constructor(
         private _store: Store<fromRoot.State>,
-        private _effects: UIEffects,
+        private _effects: UIEffects
     ) {
         this._store.select(fromRoot.getCurrent).subscribe(snippet => {
             this.isEmpty = snippet == null;

--- a/src/client/app/containers/app.ts
+++ b/src/client/app/containers/app.ts
@@ -64,7 +64,7 @@ export class AppComponent {
         });
 
         this._store.select(fromRoot.getSharing).subscribe(sharing => {
-            sharing ? this.isDisabled = true : this.isDisabled = false;
+            this.isDisabled = sharing;
         });
 
         this._store.dispatch(new GitHub.IsLoggedInAction());

--- a/src/client/app/effects/github.ts
+++ b/src/client/app/effects/github.ts
@@ -177,7 +177,7 @@ export class GitHubEffects {
                 }
             }).on('success', async() => {
                 await this._uiEffects.alert(Strings().snippetCopiedConfirmation, null, Strings().okButtonLabel);
-                this._store.dispatch(new GitHub.ShareSuccessAction(<IGist>{}));
+                this._store.dispatch(new GitHub.ShareSuccessAction(null));
             });
         })
         .catch(exception => Observable.from([

--- a/src/client/app/effects/github.ts
+++ b/src/client/app/effects/github.ts
@@ -173,12 +173,17 @@ export class GitHubEffects {
             AI.trackEvent(GitHub.GitHubActionTypes.SHARE_COPY, { id: rawSnippet.id });
             new clipboard('#CopyToClipboard', {
                 text: () => {
-                    this._uiEffects.alert(Strings().snippetCopiedConfirmation, null, Strings().okButtonLabel);
                     return yaml;
                 }
+            }).on('success', async() => {
+                await this._uiEffects.alert(Strings().snippetCopiedConfirmation, null, Strings().okButtonLabel);
+                this._store.dispatch(new GitHub.ShareSuccessAction(<IGist>{}));
             });
         })
-        .catch(exception => Observable.of(this._createShowErrorAction(Strings().snippetCopiedFailed, exception)));
+        .catch(exception => Observable.from([
+            this._createShowErrorAction(Strings().snippetCopiedFailed, exception),
+            new GitHub.ShareFailedAction(exception)
+        ]));
 
 
     @Effect({ dispatch: false })

--- a/src/client/app/reducers/github.ts
+++ b/src/client/app/reducers/github.ts
@@ -47,6 +47,7 @@ export function reducer(state = initialState, action: GitHubActions): GitHubStat
             };
         }
 
+        case GitHubActionTypes.SHARE_COPY:
         case GitHubActionTypes.SHARE_PRIVATE_GIST:
         case GitHubActionTypes.SHARE_PUBLIC_GIST:
         case GitHubActionTypes.UPDATE_GIST: {

--- a/src/client/assets/styles/components/_command.scss
+++ b/src/client/assets/styles/components/_command.scss
@@ -10,6 +10,10 @@ command {
         display: block;
     }
 
+    &.disabled .command__dropdown {
+        display: none;
+    }
+
     &.title {
         .command {
             &__icon {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Share menu would not hide when the alert dialog appeared and would still be interactive, leading to potentially undefined user actions. This has now been fixed via adding a subscription to the app's sharing state, and manually removing the menu when the state is changed through CSS styling.

This has been implemented for the relevant Share Menu items, including Update, Public gist, Secret gist, and Copy to clipboard.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/OfficeDev/script-lab/issues/490

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
