### PR TITLE
Add server-side HTML no-cache headers and client-side static asset cache headers; modify deployment script to include static resources for up to 6 months

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node --harmony
 
 let path = require('path');
+let fs = require('fs');
 let chalk = require('chalk');
 let _ = require('lodash');
 let { build, config } = require('./env.config');
@@ -101,6 +102,9 @@ function deployBuild(url, folder) {
         let next_path = path.resolve(folder);
         shell.cd(next_path);
         const start = Date.now();
+        if (url === EDITOR_URL) {
+            buildAssetHistory(url);
+        }
         shell.exec('git init');
         shell.exec('git config --add user.name "Travis CI"');
         shell.exec('git config --add user.email "travis.ci@microsoft.com"');
@@ -127,6 +131,42 @@ function deployBuild(url, folder) {
         log('Deployment failed...', 'red');
         console.log(error);
     }
+}
+
+function buildAssetHistory(url) {
+    shell.exec('git clone ' + url + ' current_build');
+    let now = (new Date().getTime()) / 1000;
+    let oldHistoryPath = path.resolve(__dirname, 'current_build/history.json');
+    let newHistoryPath = path.resolve(__dirname, 'history.json');
+    let oldAssetsPath = path.resolve(__dirname, 'current_build/bundles');
+    let newAssetsPath = path.resolve(__dirname, 'bundles');
+
+    // Parse old history file if it exists
+    let history = {};
+    try {
+        history = JSON.parse(fs.readFileSync(oldHistoryPath).toString());
+    } catch (e) {}
+
+    // Add new asset files to history, with current timestamp
+    let newAssets = fs.readdirSync(newAssetsPath);
+    for (asset of newAssets) {
+        history[asset] = { time: now };
+    }
+
+    try {
+        fs.accessSync(oldAssetsPath);
+        let existingAssets = fs.readdirSync(oldAssetsPath);
+        for (asset of existingAssets) {
+            let assetPath = path.resolve(newAssetsPath, asset);
+            // Check if old assets don't name-conflict and are less than six months old
+            if (!fs.existsSync(assetPath) && (now - history[asset].time < 15768000)) {
+                fs.writeFileSync(assetPath, fs.readFileSync(path.resolve(oldAssetsPath, asset)));
+            }
+        }
+    } catch (e) {}
+
+    fs.writeFileSync(newHistoryPath, JSON.stringify(history));
+    shell.exec('rm -rf current_build');
 }
 
 function log(message, color) {

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -11,8 +11,8 @@ module.exports = () =>
 
         output: {
             path: path.resolve('./dist/client'),
-            filename: '[name].bundle.js',
-            chunkFilename: '[name].chunk.js',
+            filename: 'bundles/[name].bundle.js',
+            chunkFilename: 'bundles/[name].chunk.js',
         },
 
         resolve: {

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -12,8 +12,8 @@ module.exports = (env) =>
 
         output: {
             path: path.resolve('./dist/client'),
-            filename: '[name].[chunkhash].bundle.js',
-            chunkFilename: '[id].chunk.js'
+            filename: 'bundles/[name].[chunkhash].bundle.js',
+            chunkFilename: 'bundles/[id].chunk.js'
         },
 
         module: {
@@ -56,7 +56,7 @@ module.exports = (env) =>
         },
 
         plugins: [
-            new ExtractTextPlugin('[name].[chunkhash].bundle.css'),
+            new ExtractTextPlugin('bundles/[name].[chunkhash].bundle.css'),
             new webpack.optimize.UglifyJsPlugin({
                 sourceMap: true,
                 compress: true,

--- a/src/client/public/web.config
+++ b/src/client/public/web.config
@@ -24,9 +24,20 @@
             <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />
             <action type="Rewrite" value="no-cache, no-store" />
           </rule>
+          <rule name="DisableCacheHTMLFiles" preCondition="IsHTMLFile">
+            <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />
+            <action type="Rewrite" value="no-cache, no-store" />
+          </rule>
+          <rule name="CacheJSFiles" preCondition="IsJSFile">
+            <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />
+            <action type="Rewrite" value="no-cache, no-store" />
+          </rule>
           <preConditions>
             <preCondition name="IsHTMLFile">
               <add input="{REQUEST_FILENAME}" pattern=".*\.html" />
+            </preCondition>
+            <preCondition name="IsJSFile">
+              <add input="{REQUEST_FILENAME}" pattern=".*\.js" />
             </preCondition>
           </preConditions>
       </outboundRules>

--- a/src/client/public/web.config
+++ b/src/client/public/web.config
@@ -24,20 +24,17 @@
             <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />
             <action type="Rewrite" value="no-cache, no-store" />
           </rule>
-          <rule name="DisableCacheHTMLFiles" preCondition="IsHTMLFile">
+          <!-- Cache static webpack assets for 6 months -->
+          <rule name="CacheStaticAssets">
             <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />
-            <action type="Rewrite" value="no-cache, no-store" />
-          </rule>
-          <rule name="CacheJSFiles" preCondition="IsJSFile">
-            <match serverVariable="RESPONSE_Cache-Control" pattern=".*" />
-            <action type="Rewrite" value="no-cache, no-store" />
+            <conditions>
+                <add input="{URL}" pattern="/bundles/" negate="false" />
+            </conditions>
+            <action type="Rewrite" value="max-age=15768000" />
           </rule>
           <preConditions>
             <preCondition name="IsHTMLFile">
               <add input="{REQUEST_FILENAME}" pattern=".*\.html" />
-            </preCondition>
-            <preCondition name="IsJSFile">
-              <add input="{REQUEST_FILENAME}" pattern=".*\.js" />
             </preCondition>
           </preConditions>
       </outboundRules>

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -434,6 +434,7 @@ async function errorHandler(res: express.Response, error: Error, strings: Server
     }
 
     const html = await generateErrorHtml(error, strings);
+    res.setHeader('Cache-Control', 'no-cache, no-store');
     return res.contentType('text/html').status(200).send(html);
 }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -120,6 +120,7 @@ registerRoute('get', '/run/:host/:id', (req, res) => {
                 explicitlySetDisplayLanguageOrNull: getExplicitlySetDisplayLanguageOrNull(req)
             });
 
+            res.setHeader('Cache-Control', 'no-cache, no-store');
             return res.contentType('text/html').status(200).send(html);
         });
 
@@ -317,6 +318,7 @@ function compileCommon(req: express.Request, res: express.Response, wrapWithRunn
             }
 
             timer.stop();
+            res.setHeader('Cache-Control', 'no-cache, no-store');
             res.contentType('text/html').status(200).send(replaceTabsWithSpaces(html));
         });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Previously, server side HTML files did not have no-cache headers. This is now fixed.

Client-side files did have no-cache headers for HTML files but did not have cache headers for static resources; this is now fixed. Static resources are cached for up to 6 months.

To ensure safe deployment, the deploy script now deploys old resources along with new resources, if the old resources are less than 6 months old. After six months, these older resources are no longer deployed, and the browser should refresh.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/OfficeDev/script-lab/issues/521
https://github.com/OfficeDev/script-lab/issues/459

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
