### PR TITLE
Fix deploy script to copy latest bundle resources from production instead of prior build

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -66,9 +66,21 @@ const RUNNER_URL = 'https://'
     + slot + '.scm.azurewebsites.net:443/'
     + AZURE_WA_SITE + '-runner.git';
 
+let copyDeployedResourcesUrl = EDITOR_URL;
+
+// For production, changes are first deployed to staging environment which gets swapped and contains the prior build.
+// We always want to copy existing bundle resources from the latest in production.
+if (slot === 'staging') {
+    copyDeployedResourcesUrl = 'https://'
+        + AZURE_WA_USERNAME + ':'
+        + AZURE_WA_PASSWORD + '@'
+        + AZURE_WA_SITE + '.scm.azurewebsites.net:443/'
+        + AZURE_WA_SITE + '.git';
+}
+
 log('Deploying commit: "' + TRAVIS_COMMIT_MESSAGE_SANITIZED + '" to ' + AZURE_WA_SITE + '-' + slot + '...');
-deployBuild(EDITOR_URL, 'dist/client');
-deployBuild(RUNNER_URL, 'dist/server');
+deployBuild(EDITOR_URL, 'dist/client', copyDeployedResourcesUrl);
+deployBuild(RUNNER_URL, 'dist/server', null);
 
 function precheck(skip) {
     if (skip) {
@@ -96,15 +108,17 @@ function precheck(skip) {
     }
 }
 
-function deployBuild(url, folder) {
+function deployBuild(url, folder, copyDeployedResourcesUrl) {
     try {
         let current_path = path.resolve();
         let next_path = path.resolve(folder);
         shell.cd(next_path);
         const start = Date.now();
-        if (url === EDITOR_URL) {
-            buildAssetHistory(url, next_path);
+
+        if (copyDeployedResourcesUrl) {
+            buildAssetHistory(copyDeployedResourcesUrl, next_path);
         }
+
         shell.exec('git init');
         shell.exec('git config --add user.name "Travis CI"');
         shell.exec('git config --add user.email "travis.ci@microsoft.com"');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For production deployment the changes are first committed to a staging environment. After successful deployment to staging, it then will get swapped with production. The problem is that we will loose the resources currently deployed to production for one deployment since we clone current_build from the prior deployment. We will still use the staging environment, but copy current_build bundle resources from the files deployed to production.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
