### PR TITLE
Changing the image descriptions to actually be useful to a screen reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/OfficeDev/script-lab.svg?token=zKp5xy2SuSortMzv5Pqc&branch=master)](https://travis-ci.com/OfficeDev/script-lab)
+﻿[![Build Status](https://travis-ci.com/OfficeDev/script-lab.svg?token=zKp5xy2SuSortMzv5Pqc&branch=master)](https://travis-ci.com/OfficeDev/script-lab)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2bd3136187484835afb55a961451b81a)](https://www.codacy.com/app/WrathOfZombies/script-lab_2?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=OfficeDev/script-lab&amp;utm_campaign=Badge_Grade)
 <a id="top"></a>
 # Script Lab, a Microsoft Garage project
@@ -34,7 +34,7 @@ Script Lab is a Microsoft Garage project that began at a hackathon. You can read
 
 Here's a 1-minute teaser video to give you a taste:
 
-[![Script Lab teaser video](.github/images/screenshot-wide-youtube.png "Script Lab teaser video")](https://aka.ms/scriptlabvideo)
+[![Script Lab teaser video showing Script Lab being used in Excel to make charts, Word, and Powerpoint Online.](.github/images/screenshot-wide-youtube.png "Script Lab teaser video")](https://aka.ms/scriptlabvideo)
 
 <a id="get-started"></a>
 ## Get Started
@@ -52,11 +52,11 @@ This 10-minute demo explains how to use the main features:
 
 Script Lab is built around sharing.  If someone gives you a URL to a GitHub GIST, simply open Script Lab, use the hamburger menu at the top left to see the menu, and choose "Import" category (either on the left or top, depending on the available screen space). Then, enter the URL of the GIST, and click the "Import" button at the bottom of the screen.  In just these few clicks, you will be able to view and run someone else's snippet!
 
-![Import tab in the "Hamburger" menu](.github/images/import-snippet.jpg)
+![Import tab within the "Hamburger" menu showing a text box to import a URL, GitHub gist ID, or snippet YAML](.github/images/import-snippet.jpg)
 
 Conversely, to share *your* snippet with someone, choose the "Share" menu within a particular snippet. You can share as a public or private [GitHub Gist](https://help.github.com/articles/about-gists/), or you can copy the entire snippet metadata to the clipboard, and share it from there.
 
-![Share menu](.github/images/share.jpg)
+![Share menu with dropdown options: public gist, secret gist, or copy to clipboard](.github/images/share.jpg)
 
 <a id="report-bug"></a>
 ## Report a bug, or suggest a feature
@@ -65,7 +65,7 @@ To report a bug, [create a new issue](https://github.com/OfficeDev/script-lab/is
 
 It can also help to provide your Script Lab User ID (we generate it randomly for each device and it stays assigned to you until you clear your browser cache). You can find this ID under the **About** section in the editor view:
 
-![About -> User ID](.github/images/screenshot-about-user-id.jpg)
+![Inside the 'about' button showing how to find the User ID location](.github/images/screenshot-about-user-id.jpg)
 
 If you have a suggestion for a feature, please feel free to file it under "issues" as well, and we will tag it appropriately.  The more detail, the better!  We also gladly accept pull requests... (see more at [CONTRIBUTING.md](CONTRIBUTING.md)).
 


### PR DESCRIPTION
Changing the image descriptions to actually be useful to a screen reader

## Description
Updated alternative text. Michael Saunders video still needs captions.

## Related Issue
[Issue #573](https://github.com/OfficeDev/script-lab/issues/573)

## Motivation and Context
Script Lab should be accessible. The documentation should also be accessible.

## How Has This Been Tested?
Reading.

## Types of changes
Minor Text Fix. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
