### PR TITLE
Improve snippet-trust experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,9 @@ There are also files related to Azure deployment, git ignores, a Travis configur
 ## Enabling auth for local testing (optional, if debugging auth-related code)
 1. Go to <https://github.com/settings/developers>, and click "[Register new application](https://github.com/settings/applications/new)" if you haven't done it before for your own dev copy of ScriptLab.
 2. Give it a name like "ScriptLab Local Dev", with a Homepage and Auth callback URL of `https://localhost:3000`.
-3. In `config/env.config.js`, find the `const config = { ... ` line, and under `local: { ...`, find `clientId: ''`, and replace with `clientId: '<id-from-github>'`.
-4. In `server/server.ts`, find `client_secret: secrets ? secrets[env] : '',`, and replace it with `secrets ? secrets[env] : '<client-secret-from-github>'`.
-5. If the site is running, re-start it and do a new `npm start`.  Incremental compilation is not enough for these changes. Note, too, that you need both the site and the server (F5) running to make auth work.
-6. Once you are done with your testing, **be sure to undo both changes!**.
+3. In `config/env.config.js`, find the `const config = { ... ` line, and under `local: { ...`, fill in the client ID and client secret
+4. If the site is running, re-start it and do a new `npm start`.  Incremental compilation is not enough for these changes. Note, too, that you need both the site and the server (F5) running to make auth work.
+5. Once you are done with your testing, **be sure to undo both changes!**.
 
 
 # Manual-testing scenarios

--- a/config/env.config.js
+++ b/config/env.config.js
@@ -21,6 +21,7 @@ const config = {
     local: {
         name: 'LOCAL',
         clientId: '',
+        clientSecretLocalHost: '',
         instrumentationKey: null,
         editorUrl: 'https://localhost:3000',
         tokenUrl: 'https://localhost:3200/auth',

--- a/src/client/app/effects/github.ts
+++ b/src/client/app/effects/github.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { PlaygroundError, AI, getShareableYaml, environment, storage, getGistUrl, trustedSnippetManager } from '../helpers';
+import { PlaygroundError, AI, getShareableYaml, environment, getGistUrl } from '../helpers';
 import { Strings, getDisplayLanguage } from '../strings';
 import { GitHubService } from '../services';
 import { Store, Action } from '@ngrx/store';
@@ -128,7 +128,7 @@ export class GitHubEffects {
                 throw exception;
             }))
             .mergeMap(async ({ type, gist, snippetId }) => {
-                let gistUrl = getGistUrl(gist.id);
+                let gistUrl = getGistUrl((gist as IGist).id);
                 let messageBody =
                     type === GitHub.GitHubActionTypes.UPDATE_GIST ?
                         `${Strings().gistUpdateUrlIsSameAsBefore}\n\n${gistUrl}` :
@@ -141,14 +141,7 @@ export class GitHubEffects {
                     window.open(gistUrl);
                 }
 
-                return { gist: gist, snippetId: snippetId };
-            })
-            .do(({ gist, snippetId }) => {
-                let snippet = storage.snippets.get(snippetId);
-                // If original snippet wasn't a gist and wasn't already trusted, trust it on share
-                if (snippet && !snippet.gist && !trustedSnippetManager.isSnippetTrusted(snippetId, gist.id)) {
-                    trustedSnippetManager.updateTrustedSnippets(snippetId);
-                }
+                return { gist: gist as IGist, snippetId: snippetId };
             })
             .mergeMap(({ gist, snippetId }) => Observable.from([
                 new GitHub.LoadGistsAction(),

--- a/src/client/app/effects/snippet.ts
+++ b/src/client/app/effects/snippet.ts
@@ -139,7 +139,7 @@ export class SnippetEffects {
                     displayLanguage: getDisplayLanguage()
                 };
                 const data = JSON.stringify(state);
-                const isTrustedSnippet = trustedSnippetManager.isSnippetTrusted(snippet.id, snippet.gist);
+                const isTrustedSnippet = trustedSnippetManager.isSnippetTrusted(snippet.id, snippet.gist, snippet.gistOwnerId);
 
                 AI.trackEvent('[Runner] Running Snippet', { snippet: snippet.id });
                 post(environment.current.config.runnerUrl + '/compile/page', { data, isTrustedSnippet });
@@ -411,10 +411,6 @@ export class SnippetEffects {
         snippet.id = snippet.id === '' ? cuid() : snippet.id;
         snippet.gist = rawSnippet.gist;
         snippet.gistOwnerId = rawSnippet.gistOwnerId;
-
-        if (snippet.gist && this._github.profile && this._github.profile.login === snippet.gistOwnerId) {
-            trustedSnippetManager.updateTrustedSnippets(snippet.id);
-        }
 
         let properties = {};
         if (mode === Snippet.ImportType.GIST) {

--- a/src/client/app/helpers/trusted.snippet.helper.ts
+++ b/src/client/app/helpers/trusted.snippet.helper.ts
@@ -14,10 +14,17 @@ class TrustedSnippet {
         } catch (e) { }
     }
 
-    isSnippetTrusted(snippetId: string, gistId: string): boolean {
-        /* Samples are automatically trusted. Check local storage for gists. */
+    isSnippetTrusted(snippetId: string, gistId: string, gistOwnerId: string): boolean {
+        /* Samples or locally-created snippets are automatically trusted.
+           I's only the Gists that you need to watch out for. */
         if (!gistId) {
             return true;
+        }
+
+        if (storage.current.profile && storage.current.profile.login) {
+            if (storage.current.profile.login === gistOwnerId) {
+                return true;
+            }
         }
 
         try {
@@ -31,7 +38,7 @@ class TrustedSnippet {
         }
     }
 
-    updateTrustedSnippets(snippetId: string): void {
+    trustSnippet(snippetId: string): void {
         try {
             let trustedSnippets = JSON.parse(window.localStorage.getItem(TRUSTED_SNIPPETS_KEY));
             if (!trustedSnippets) {

--- a/src/client/public/gallery.ts
+++ b/src/client/public/gallery.ts
@@ -158,7 +158,7 @@ export class Gallery {
             displayLanguage: getDisplayLanguage()
         };
         const data = JSON.stringify(state);
-        const isTrustedSnippet = trustedSnippetManager.isSnippetTrusted(snippet.id, snippet.gist);
+        const isTrustedSnippet = trustedSnippetManager.isSnippetTrusted(snippet.id, snippet.gist, snippet.gistOwnerId);
 
         this.showProgress(`${Strings().HtmlPageStrings.running} "${snippet.name}"`);
         return post(environment.current.config.runnerUrl + '/compile/page', { data, isTrustedSnippet });

--- a/src/client/public/heartbeat.ts
+++ b/src/client/public/heartbeat.ts
@@ -101,7 +101,7 @@ import { Authenticator } from '@microsoft/office-js-helpers';
 
         // Upon user trusting snippet, update in local storage
         if (isTrustedSnippet) {
-            trustedSnippetManager.updateTrustedSnippets(snippet.id);
+            trustedSnippetManager.trustSnippet(snippet.id);
         }
 
         if (snippet.modified_at !== trackingSnippet.lastModified) {
@@ -111,7 +111,7 @@ import { Authenticator } from '@microsoft/office-js-helpers';
             const sendImmediately = trackingSnippet.lastModified < 1;
             if (sendImmediately) {
                 trackingSnippet.lastModified = snippet.modified_at;
-                isTrustedSnippet = trustedSnippetManager.isSnippetTrusted(snippet.id, snippet.gist);
+                isTrustedSnippet = trustedSnippetManager.isSnippetTrusted(snippet.id, snippet.gist, snippet.gistOwnerId);
                 messenger.send(window.parent, MessageType.REFRESH_RESPONSE, { snippet: snippet, isTrustedSnippet: isTrustedSnippet });
             } else {
                 messenger.send<{name: string}>(window.parent, MessageType.INFORM_STALE, {

--- a/src/client/public/runner.ts
+++ b/src/client/public/runner.ts
@@ -30,7 +30,6 @@ interface InitializationParams {
     let host: string;
 
     let currentSnippet: { id: string, lastModified: number, officeJS: string };
-    let notifySnippetNotTrustedDisplayed: boolean;
 
     const defaultIsListeningTo = {
         snippetSwitching: true,
@@ -135,8 +134,9 @@ interface InitializationParams {
     (window as any).initializeRunner = initializeRunner;
 
 
-    /** Creates a snippet iframe and returns it (still hidden) */
-    function replaceSnippetIframe(html: string, officeJS: string, isTrustedSnippet: boolean): void {
+    /** Creates a snippet iframe and returns it (still hidden). Returns true on success
+     * (e.g., snippet indeed shown, in contrast with, say, the Trust dialog being shown, but not the snippet) */
+    function replaceSnippetIframe(html: string, officeJS: string, isTrustedSnippet: boolean): boolean {
         showHeader();
 
         // Remove any previous iFrames (if any) or the placeholder snippet-frame div
@@ -146,18 +146,12 @@ interface InitializationParams {
             .insertAfter($snippetContent);
 
         if (!isTrustedSnippet) {
-            notifySnippetNotTrustedDisplayed = true;
             showReloadNotification($('#notify-snippet-not-trusted'),
-                () => {
-                    notifySnippetNotTrustedDisplayed = false;
-                    clearAndRefresh(currentSnippet.id, '', true /*isTrustedSnippet*/);
-                },
-                () => {
-                    notifySnippetNotTrustedDisplayed = false;
-                    window.location.href = returnUrl;
-                }
+                () => clearAndRefresh(currentSnippet.id, '', true /*isTrustedSnippet*/),
+                () => window.location.href = returnUrl,
+                false /*allowShowLoadingDots => not for trust dialog*/
             );
-            return;
+            return false;
         }
 
         const $iframe =
@@ -203,6 +197,8 @@ interface InitializationParams {
         (contentWindow as any).console = window.console;
         contentWindow.onerror = (...args) => console.error(args);
         contentWindow.document.close();
+
+        return true;
     }
 
     function handleError(error: Error) {
@@ -317,7 +313,9 @@ interface InitializationParams {
                 if (isListeningTo.currentSnippetContentChange) {
                     showReloadNotification($('#notify-current-snippet-changed'),
                         () => clearAndRefresh(currentSnippet.id, input.message.name, false /*isTrustedSnippet*/),
-                        () => isListeningTo.currentSnippetContentChange = false);
+                        () => isListeningTo.currentSnippetContentChange = false,
+                        true, /*allowShowLoadingDots*/
+                    );
                 }
             });
 
@@ -335,7 +333,8 @@ interface InitializationParams {
                         $anotherSnippetSelected.find('.ms-MessageBar-text .snippet-name').text(input.message.name);
                         showReloadNotification($anotherSnippetSelected,
                             () => clearAndRefresh(input.message.id, input.message.name, false /*isTrustedSnippet*/),
-                            () => isListeningTo.snippetSwitching = false);
+                            () => isListeningTo.snippetSwitching = false,
+                            true /*allowShowLoadingDots*/);
                     }
                 }
             });
@@ -353,22 +352,11 @@ interface InitializationParams {
                 // (don't want to navigate, just to do an AJAX call)
                 $.post(window.location.origin + '/compile/snippet', { data: data, isTrustedSnippet: input.message.isTrustedSnippet })
                     .then(html => processSnippetReload(html, snippet, input.message.isTrustedSnippet))
-                    .fail(handleError)
-                    .always(() => {
-                        if (!notifySnippetNotTrustedDisplayed) {
-                            $('.runner-overlay').hide();
-                            $('.runner-notification').not('#notify-error').hide();
-                        }
-                    });
+                    .fail(handleError);
             });
     }
 
-    function showReloadNotification($notificationContainer: JQuery, reloadAction: () => void, dismissAction: () => void) {
-        /* Do not display other messages while the trust snippet message is displayed */
-        if (notifySnippetNotTrustedDisplayed && $notificationContainer.attr('id') !== 'notify-snippet-not-trusted') {
-            return;
-        }
-
+    function showReloadNotification($notificationContainer: JQuery, reloadAction: () => void, dismissAction: () => void, allowShowLoadingDots: boolean) {
         $notificationContainer.find('.action-fast-reload').off('click').click(() => {
             reloadAction();
         });
@@ -379,10 +367,7 @@ interface InitializationParams {
             dismissAction();
         });
 
-        if (notifySnippetNotTrustedDisplayed) {
-            /* Hide loading dots */
-            $('.cs-loader').css('visibility', 'hidden');
-        }
+        $('.cs-loader').css('visibility', allowShowLoadingDots ? 'visible' : 'hidden');
 
         // Show the current notification (and hide any others)
         $('.runner-notification').hide();
@@ -413,12 +398,17 @@ interface InitializationParams {
 
         $('#header-refresh').attr('href', refreshUrl);
 
-        replaceSnippetIframe(html, processLibraries(snippet).officeJS, isTrustedSnippet);
+        let replacedSuccessfully = replaceSnippetIframe(html, processLibraries(snippet).officeJS, isTrustedSnippet);
 
         $('#header-text').text(snippet.name);
         currentSnippet.lastModified = snippet.modified_at;
 
         (window as any).Firebug.Console.clear();
+
+        if (replacedSuccessfully) {
+            $('.runner-overlay').hide();
+            $('.runner-notification').hide();
+        }
     }
 
     /** Clear current snippet frame and send a refresh REFRESH_REQUEST

--- a/src/interfaces/github.d.ts
+++ b/src/interfaces/github.d.ts
@@ -1,8 +1,3 @@
-interface IProfile {
-    user: IBasicProfile,
-    orgs: IBasicProfile[]
-}
-
 interface IBasicProfile {
     login?: string,
     id?: number,

--- a/src/interfaces/playground.d.ts
+++ b/src/interfaces/playground.d.ts
@@ -109,7 +109,7 @@ interface ICompiledPlaygroundInfo {
     devMode: boolean;
     build: IBuildInfo;
     config: {
-        local: IEnvironmentConfig,
+        local: ILocalHostEnvironmentConfig,
         edge: IEnvironmentConfig,
         insiders: IEnvironmentConfig,
         production: IEnvironmentConfig
@@ -138,7 +138,7 @@ interface IBuildInfo {
 }
 
 interface IEnvironmentConfig {
-    name: string,
+    name: 'LOCAL' | 'EDGE' | 'INSIDERS' | 'PRODUCTION',
     clientId: string
     instrumentationKey: string,
     editorUrl: string,
@@ -148,9 +148,13 @@ interface IEnvironmentConfig {
     samplesUrl: string
 }
 
+interface ILocalHostEnvironmentConfig extends IEnvironmentConfig {
+    clientSecretLocalHost: string;
+}
+
 interface ISettings {
     lastOpened: ISnippet,
-    profile: IProfile,
+    profile: IBasicProfile,
     theme: boolean,
     language: string,
     env: string

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -231,7 +231,7 @@ registerRoute('post', '/auth/:user', (req, res) => {
             },
             json: {
                 client_id: clientId,
-                client_secret: secrets ? secrets[env] : '',
+                client_secret: getClientSecret(),
                 redirect_uri: editorUrl,
                 code,
                 state
@@ -743,4 +743,13 @@ function getRuntimeHelpersUrl() {
     }
 
     return _runtimeHelpersUrl;
+}
+
+
+function getClientSecret() {
+    if (currentConfig.name === 'LOCAL') {
+        return (currentConfig as ILocalHostEnvironmentConfig).clientSecretLocalHost;
+    };
+
+    return secrets ? secrets[env] : '';
 }


### PR DESCRIPTION
In today's code, the snippet-trust was happening at the wrong point in time: adding to the trusted list when clicking "run".  This means that for snippets already shared before by the user, where there is already a gist ID, the trust experience would appear for his/her own snippets.

There were two other bugs:
* The trust dialog appeared above the others, so a snippet-switch message would not get show after you landed on an untrusted snippet.
* The trust dialog would sometimes get shown and then immeditely hidden, making the snippet appear frozen (and with no user action to unfreeze)