### PR TITLE
Update target URL for 'Reference Docs' button

### DIFF
--- a/src/client/public/functions.ts
+++ b/src/client/public/functions.ts
@@ -7,10 +7,10 @@ Office.initialize = () => {
         code: `${window.location.origin}/?mode=${Utilities.host}`,
         playground_help: 'https://github.com/OfficeDev/script-lab/blob/master/README.md',
         ask: 'https://stackoverflow.com/questions/tagged/office-js',
-        excel_api: 'https://dev.office.com/docs/add-ins/excel/excel-add-ins-javascript-programming-overview',
+        excel_api: 'https://dev.office.com/reference/add-ins/excel/excel-add-ins-reference-overview',
         word_api: 'https://dev.office.com/reference/add-ins/word/word-add-ins-reference-overview',
-        onenote_api: 'https://dev.office.com/docs/add-ins/onenote/onenote-add-ins-programming-overview',
-        outlook_api: 'https://docs.microsoft.com/en-us/outlook/add-ins/',
+        onenote_api: 'https://dev.office.com/reference/add-ins/onenote/onenote-add-ins-javascript-reference',
+        outlook_api: 'https://docs.microsoft.com/en-us/outlook/add-ins/reference',
         powepoint_api: 'https://dev.office.com/docs/add-ins/powerpoint/powerpoint-add-ins',
         project_api: 'https://dev.office.com/reference/add-ins/shared/projectdocument.projectdocument',
         generic_api: 'https://dev.office.com/reference/add-ins/javascript-api-for-office'


### PR DESCRIPTION
## Description
Updated the target URL for the 'Reference Docs' button (Excel, OneNote, Outlook).

## Related Issue
https://github.com/OfficeDev/script-lab/issues/648

## Motivation and Context
Change is required so that users are led to most relevant/useful docs when they click the 'Reference Docs' button in Script Lab.

## How Has This Been Tested?
I've verified that each of the URLs I added is valid and links to the desired location, and have tested Script Lab running on localhost after making these changes to verify that clicking the Reference Docs button loads the correct page in the docs.

## Screenshots (if appropriate):
n/a 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
