### PR TITLE
Change outlook support to limit samples to the loaded endpoint

### DIFF
--- a/manifests/script-lab-local.outlook.xml
+++ b/manifests/script-lab-local.outlook.xml
@@ -309,69 +309,49 @@
         <bt:String id="PG.TabLabel" DefaultValue="[DEV] Script Lab" />
         <bt:String id="PG.GroupLabel" DefaultValue="Script" />
         <bt:String id="PG.AboutGroupLabel" DefaultValue="About Script Lab">
-          <Override Locale="de" Value="Über Script Lab"/>
         </bt:String>
         <bt:String id="PG.ApiGroupLabel" DefaultValue="About the APIs">
-          <Override Locale="de" Value="Über die APIs"/>
         </bt:String>
         <bt:String id="PG.CodeCommand.Label" DefaultValue="Code" />
         <bt:String id="PG.CodeCommand.Title" DefaultValue="Code" />
         <bt:String id="PG.CodeCommand.TipTitle" DefaultValue="Create or edit code snippets">
-          <Override Locale="de" Value="Erstellen oder Editieren von Code-Schnipseln"/>
         </bt:String>
         <bt:String id="PG.RunCommand.Label" DefaultValue="Run">
-          <Override Locale="de" Value="Ausführen"/>
         </bt:String>
         <bt:String id="PG.RunCommand.Title" DefaultValue="Run">
-          <Override Locale="de" Value="Ausführen"/>
         </bt:String>
         <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Run the code snippet">
-          <Override Locale="de" Value="Code-Schnipsel ausführen"/>
         </bt:String>
         <bt:String id="PG.TutorialCommand.Label" DefaultValue="Tutorial" />
         <bt:String id="PG.TutorialCommand.TipTitle" DefaultValue="Script Lab tutorial">
-          <Override Locale="de" Value="Tutorial zu Script Lab"/>
         </bt:String>
         <bt:String id="PG.HelpCommand.Label" DefaultValue="Help">
-          <Override Locale="de" Value="Hilfe"/>
         </bt:String>
         <bt:String id="PG.HelpCommand.TipTitle" DefaultValue="Help for Script Lab">
-          <Override Locale="de" Value="Hilfe zu Script Lab"/>
         </bt:String>
         <bt:String id="PG.ApiDocsCommand.Label" DefaultValue="Reference Docs">
-          <Override Locale="de" Value="Dokumentation"/>
         </bt:String>
         <bt:String id="PG.ApiDocsCommand.TipTitle" DefaultValue="API Reference Documentation">
-          <Override Locale="de" Value="API-Dokumentation"/>
         </bt:String>
         <bt:String id="PG.AskCommand.Label" DefaultValue="Ask the Community">
-          <Override Locale="de" Value="Community"/>
         </bt:String>
         <bt:String id="PG.AskCommand.TipTitle" DefaultValue="Get API help from the community">
-          <Override Locale="de" Value="Unterstützung durch die Community"/>
         </bt:String>
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="PG.CodeSupertip.Desc" DefaultValue="Opens the Script Lab code editor">
-          <Override Locale="de" Value="Den Script Lab Code-Editor aufrufen."/>
         </bt:String>
         <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet">
-          <Override Locale="de" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
         </bt:String>
         <bt:String id="PG.TutorialCommand.Desc" DefaultValue="Launches a quick Script Lab tutorial">
-          <Override Locale="de" Value="Ein Tutorial zu Script Lab aufrufen."/>
         </bt:String>
         <bt:String id="PG.HelpCommand.Desc" DefaultValue="Launches documentation on using Script Lab">
-          <Override Locale="de" Value="Die Dokumentation zu Script Lab aufrufen."/>
         </bt:String>
         <bt:String id="PG.ApiDocsCommand.Desc" DefaultValue="Opens the API documentation for the Office application that you are running">
-          <Override Locale="de" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
         </bt:String>
         <bt:String id="PG.AskCommand.Desc" DefaultValue="Launches a community forum for questions about the Office JavaScript APIs">
-          <Override Locale="de" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
         </bt:String>
         <bt:String id="PG.Description" DefaultValue="Code, run, and share your Add-in snippets directly from Office.">
-          <Override Locale="de" Value="JavaScript-Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
         </bt:String>
       </bt:LongStrings>
     </Resources>

--- a/src/client/app/effects/snippet.ts
+++ b/src/client/app/effects/snippet.ts
@@ -16,6 +16,14 @@ import { isEmpty, isNil, find, assign, reduce, forIn, isEqual } from 'lodash';
 import * as sha1 from 'crypto-js/sha1';
 import { Utilities, HostType } from '@microsoft/office-js-helpers';
 
+function playlistUrl(): string {
+    let host = environment.current.host.toLowerCase();
+    if (environment.current.endpoint !== undefined) {
+        host += `-${environment.current.endpoint}`;
+    }
+    return `${environment.current.config.samplesUrl}/playlists/${host}.yaml`;
+}
+
 @Injectable()
 export class SnippetEffects {
     constructor(
@@ -150,7 +158,7 @@ export class SnippetEffects {
         .map((action: Snippet.LoadTemplatesAction) => action.payload)
         .mergeMap(source => {
             if (source === 'LOCAL') {
-                let snippetJsonUrl = `${environment.current.config.samplesUrl}/playlists/${environment.current.host.toLowerCase()}.yaml`;
+                let snippetJsonUrl = playlistUrl();
                 return this._request.get<ITemplate[]>(snippetJsonUrl, ResponseTypes.YAML);
             }
             else {

--- a/src/client/app/helpers/environment.ts
+++ b/src/client/app/helpers/environment.ts
@@ -60,14 +60,10 @@ class Environment {
             return Promise.resolve({ currHost, currPlatform });
         }
 
-        if (this.current && this.current.host) {
-            return this.current;
-        }
-
-        let { host, platform } = await new Promise<{ host: string, platform: string }>(resolve => {
+        let { host, platform, endpoint } = await new Promise<{ host: string, platform: string, endpoint?: string }>(resolve => {
             if (window.location.search.toLowerCase().indexOf('mode') > 0) {
-                let { mode } = Authenticator.getUrlParams(window.location.search, '', '?') as any;
-                return resolve({ host: mode.toUpperCase(), platform: null });
+                let { mode, endpoint } = Authenticator.getUrlParams(window.location.search, '', '?') as any;
+                return resolve({ host: mode.toUpperCase(), platform: null, endpoint });
             } else if (/#\/view/.test(location.hash)) {
                 const [view, type, host] = location.hash.toLowerCase().replace('#/', '').split('/');
                 if (view && type && host) {
@@ -94,7 +90,7 @@ class Environment {
             }
         });
 
-        this.current = { host, platform };
+        this.current = { host, platform, endpoint };
         return this.current;
     }
 }

--- a/src/client/public/functions.ts
+++ b/src/client/public/functions.ts
@@ -4,7 +4,11 @@ Office.initialize = () => {
     const urls = {
         //tutorial: `${window.location.origin}/assets/documents/script-lab-tutorial.xlsx`,
         tutorial: `${window.location.origin}/tutorial.html`,
-        code: `${window.location.origin}/?mode=${Utilities.host}`,
+        code: () => {
+            const item = Office.context.mailbox.item as Office.MessageRead;
+            const endpoint = `${item.itemType}${item.itemId !== undefined ? 'read' : 'compose'}`;
+            return `${window.location.origin}/?mode=${Utilities.host}&endpoint=${endpoint}`;
+        },
         playground_help: 'https://github.com/OfficeDev/script-lab/blob/master/README.md',
         ask: 'https://stackoverflow.com/questions/tagged/office-js',
         excel_api: 'https://dev.office.com/docs/add-ins/excel/excel-add-ins-javascript-programming-overview',
@@ -45,7 +49,7 @@ Office.initialize = () => {
         launchInDialog(`${window.location.origin}/external-page.html?destination=${encodeURIComponent(url)}`, event, options);
     };
 
-    (window as any).launchCode = (event) => launchInDialog(urls.code, event, { width: 75, height: 75, displayInIframe: false });
+    (window as any).launchCode = (event) => launchInDialog(urls.code(), event, { width: 75, height: 75, displayInIframe: false });
 
     (window as any).launchTutorial = (event) => launchInDialog(urls.tutorial, event, { width: 35, height: 45 });
 

--- a/src/interfaces/playground.d.ts
+++ b/src/interfaces/playground.d.ts
@@ -116,6 +116,7 @@ interface IEnvironment {
     config?: IEnvironmentConfig
     host?: string,
     platform?: string,
+    endpoint?: string,
     PLAYGROUND_ORIGIN?: string,
     PLAYGROUND_REDIRECT?: string
 }


### PR DESCRIPTION
Changed how playlists are received to provide different playlists for each of the four Outlook cases (read/compose mail/calendar). This cannot be pulled into master until the new playlists are pulled into the office-js-snippets repo

## Motivation and Context
Because Outlook APIs change between contexts, a snippet that works in mail read may not work in mail compose and vice versa, so the user should only see samples that work in the context that they are currently in.

## How Has This Been Tested?
Tested locally pointing to a local version of office-js-snippets


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
