### PR TITLE
Change outlook support to limit samples to the loaded endpoint

### DIFF
--- a/src/client/app/effects/snippet.ts
+++ b/src/client/app/effects/snippet.ts
@@ -18,6 +18,14 @@ import { isEmpty, isNil, find, assign, reduce, forIn, isEqual } from 'lodash';
 import * as sha1 from 'crypto-js/sha1';
 import { Utilities, HostType } from '@microsoft/office-js-helpers';
 
+function playlistUrl() {
+    let host = environment.current.host.toLowerCase();
+    if (environment.current.endpoint !== null) {
+        host += `-${environment.current.endpoint}`;
+    }
+    return `${environment.current.config.samplesUrl}/playlists/${host}.yaml`;
+}
+
 @Injectable()
 export class SnippetEffects {
     constructor(
@@ -173,7 +181,7 @@ export class SnippetEffects {
         .map((action: Snippet.LoadTemplatesAction) => action.payload)
         .mergeMap(source => {
             if (source === 'LOCAL') {
-                let snippetJsonUrl = `${environment.current.config.samplesUrl}/playlists/${environment.current.host.toLowerCase()}.yaml`;
+                let snippetJsonUrl = playlistUrl();
                 return this._request.get<ITemplate[]>(snippetJsonUrl, ResponseTypes.YAML);
             }
             else {

--- a/src/client/app/helpers/environment.ts
+++ b/src/client/app/helpers/environment.ts
@@ -64,6 +64,7 @@ class Environment {
 
                 host: null,
                 platform: null,
+                endpoint: null,
 
                 runtimeSessionTimestamp: (new Date()).getTime().toString()
             };
@@ -164,6 +165,7 @@ class Environment {
             commands: any/* whether app-commands are available, relevant for Office Add-ins */,
             mode: string /* and older way of opening Script Lab to a particular host */,
             host: string /* same as "mode", also needed here so that overrides can also have this parameter */,
+            endpoint: string /* Defines which type of outlook experience is active */,
             wacUrl: string,
             tryIt: any,
         };
@@ -200,6 +202,9 @@ class Environment {
             }
             if (isValidHost(pageParams.mode)) {
                 this.appendCurrent({ host: pageParams.mode.toUpperCase() });
+                if (pageParams.endpoint) {
+                    this.appendCurrent({endpoint: pageParams.endpoint.toLowerCase()});
+                }
                 return true;
             }
         }

--- a/src/client/public/functions.ts
+++ b/src/client/public/functions.ts
@@ -3,7 +3,11 @@ const { safeExternalUrls } = PLAYGROUND;
 
 Office.initialize = () => {
     const tutorialUrl = `${window.location.origin}/tutorial.html`;
-    const codeUrl = `${window.location.origin}/?mode=${Utilities.host}`;
+    function codeUrl() {
+            const item = Office.context.mailbox.item as Office.MessageRead;
+            const endpoint = `${item.itemType}${item.itemId !== undefined ? 'read' : 'compose'}`;
+            return `${window.location.origin}/?mode=${Utilities.host}&endpoint=${endpoint}`;
+        }
 
     const launchInDialog = (url: string, event?: any, options?: { width?: number, height?: number, displayInIframe?: boolean }) => {
         options = options || {};
@@ -34,7 +38,7 @@ Office.initialize = () => {
         launchInDialog(`${window.location.origin}/external-page.html?destination=${encodeURIComponent(url)}`, event, options);
     };
 
-    (window as any).launchCode = (event) => launchInDialog(codeUrl, event, { width: 75, height: 75, displayInIframe: false });
+    (window as any).launchCode = (event) => launchInDialog(codeUrl(), event, { width: 75, height: 75, displayInIframe: false });
 
     (window as any).launchTutorial = (event) => launchInDialog(tutorialUrl, event, { width: 35, height: 45 });
 

--- a/src/interfaces/playground.d.ts
+++ b/src/interfaces/playground.d.ts
@@ -211,6 +211,7 @@ interface ICurrentPlaygroundInfo {
     config: Readonly<IEnvironmentConfig>;
     host: Readonly<string>;
     platform: Readonly<string>;
+    endpoint: Readonly<string>;
 
     /** A timestamp specifically for the in-memory session (i.e.,
      * even more short-term than sessionStorage, which has a lifetime-of-tab duration;


### PR DESCRIPTION
Changed how playlists are received to provide different playlists for each of the four Outlook cases (read/compose mail/calendar). This cannot be pulled into master until the new playlists are pulled into the office-js-snippets repo

## Motivation and Context
Because Outlook APIs change between contexts, a snippet that works in mail read may not work in mail compose and vice versa, so the user should only see samples that work in the context that they are currently in.

## How Has This Been Tested?
Tested locally pointing to a local version of office-js-snippets


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
