### PR TITLE
Fix missing XML namespace prefixes.

### DIFF
--- a/manifests/script-lab-prod.xml
+++ b/manifests/script-lab-prod.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OfficeApp 
-  xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" 
+<OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
   xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" 
   xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
@@ -62,8 +61,7 @@
     <SourceLocation DefaultValue="https://script-lab.azureedge.net" />
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
-  <VersionOverrides 
-    xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
+  <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Description resid="PG.Description" />
     <Hosts>
       <Host xsi:type="Workbook">
@@ -522,513 +520,513 @@
         <bt:String id="PG.TabLabel" DefaultValue="Script Lab" />
         <bt:String id="PG.GroupLabel" DefaultValue="Script" />
         <bt:String id="PG.AboutGroupLabel" DefaultValue="About Script Lab">
-          <Override Locale="de-de" Value="Über Script Lab"/>
-          <Override Locale="de-ch" Value="Über Script Lab"/>
-          <Override Locale="de-at" Value="Über Script Lab"/>
-          <Override Locale="es-ar" Value="Acerca de Script Lab"/>
-          <Override Locale="es-bo" Value="Acerca de Script Lab"/>
-          <Override Locale="es-cl" Value="Acerca de Script Lab"/>
-          <Override Locale="es-co" Value="Acerca de Script Lab"/>
-          <Override Locale="es-cr" Value="Acerca de Script Lab"/>
-          <Override Locale="es-do" Value="Acerca de Script Lab"/>
-          <Override Locale="es-ec" Value="Acerca de Script Lab"/>
-          <Override Locale="es-sv" Value="Acerca de Script Lab"/>
-          <Override Locale="es-gt" Value="Acerca de Script Lab"/>
-          <Override Locale="es-hn" Value="Acerca de Script Lab"/>
-          <Override Locale="es-mx" Value="Acerca de Script Lab"/>
-          <Override Locale="es-ni" Value="Acerca de Script Lab"/>
-          <Override Locale="es-pa" Value="Acerca de Script Lab"/>
-          <Override Locale="es-py" Value="Acerca de Script Lab"/>
-          <Override Locale="es-pe" Value="Acerca de Script Lab"/>
-          <Override Locale="es-pr" Value="Acerca de Script Lab"/>
-          <Override Locale="es-es" Value="Acerca de Script Lab"/>
-          <Override Locale="es-uy" Value="Acerca de Script Lab"/>
-          <Override Locale="es-mx" Value="Acerca de Script Lab"/>
-          <Override Locale="zh-cn" Value="关于Script Lab"/>
+          <bt:Override Locale="de-de" Value="Über Script Lab"/>
+          <bt:Override Locale="de-ch" Value="Über Script Lab"/>
+          <bt:Override Locale="de-at" Value="Über Script Lab"/>
+          <bt:Override Locale="es-ar" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-bo" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-cl" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-co" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-cr" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-do" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-ec" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-sv" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-gt" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-hn" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-ni" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-pa" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-py" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-pe" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-pr" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-es" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-uy" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="zh-cn" Value="关于Script Lab"/>
         </bt:String>
         <bt:String id="PG.ApiGroupLabel" DefaultValue="About the APIs">
-          <Override Locale="de-de" Value="Über die APIs"/>
-          <Override Locale="de-ch" Value="Über die APIs"/>
-          <Override Locale="de-at" Value="Über die APIs"/>
-          <Override Locale="es-ar" Value="Acerca de las APIs"/>
-          <Override Locale="es-bo" Value="Acerca de las APIs"/>
-          <Override Locale="es-cl" Value="Acerca de las APIs"/>
-          <Override Locale="es-co" Value="Acerca de las APIs"/>
-          <Override Locale="es-cr" Value="Acerca de las APIs"/>
-          <Override Locale="es-do" Value="Acerca de las APIs"/>
-          <Override Locale="es-ec" Value="Acerca de las APIs"/>
-          <Override Locale="es-sv" Value="Acerca de las APIs"/>
-          <Override Locale="es-gt" Value="Acerca de las APIs"/>
-          <Override Locale="es-hn" Value="Acerca de las APIs"/>
-          <Override Locale="es-mx" Value="Acerca de las APIs"/>
-          <Override Locale="es-ni" Value="Acerca de las APIs"/>
-          <Override Locale="es-pa" Value="Acerca de las APIs"/>
-          <Override Locale="es-py" Value="Acerca de las APIs"/>
-          <Override Locale="es-pe" Value="Acerca de las APIs"/>
-          <Override Locale="es-pr" Value="Acerca de las APIs"/>
-          <Override Locale="es-es" Value="Acerca de las APIs"/>
-          <Override Locale="es-uy" Value="Acerca de las APIs"/>
-          <Override Locale="es-mx" Value="Acerca de las APIs"/>
-          <Override Locale="zh-cn" Value="关于APIs"/>
+          <bt:Override Locale="de-de" Value="Über die APIs"/>
+          <bt:Override Locale="de-ch" Value="Über die APIs"/>
+          <bt:Override Locale="de-at" Value="Über die APIs"/>
+          <bt:Override Locale="es-ar" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-bo" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-cl" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-co" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-cr" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-do" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-ec" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-sv" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-gt" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-hn" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-mx" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-ni" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-pa" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-py" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-pe" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-pr" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-es" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-uy" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-mx" Value="Acerca de las APIs"/>
+          <bt:Override Locale="zh-cn" Value="关于APIs"/>
         </bt:String>
         <bt:String id="PG.CodeCommand.Label" DefaultValue="Code" />
         <bt:String id="PG.CodeCommand.Title" DefaultValue="Code" />
         <bt:String id="PG.CodeCommand.TipTitle" DefaultValue="Create or edit code snippets">
-          <Override Locale="de-de" Value="Erstellen oder Editieren von Code-Schnipseln"/>
-          <Override Locale="de-ch" Value="Erstellen oder Editieren von Code-Schnipseln"/>
-          <Override Locale="de-at" Value="Erstellen oder Editieren von Code-Schnipseln"/>
-          <Override Locale="es-ar" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-bo" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-cl" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-co" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-cr" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-do" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-ec" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-sv" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-gt" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-hn" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-mx" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-ni" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-pa" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-py" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-pe" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-pr" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-es" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-uy" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="es-mx" Value="Crea o edita fragmentos de código"/>
-          <Override Locale="zh-cn" Value="创建或编辑代码段"/>
+          <bt:Override Locale="de-de" Value="Erstellen oder Editieren von Code-Schnipseln"/>
+          <bt:Override Locale="de-ch" Value="Erstellen oder Editieren von Code-Schnipseln"/>
+          <bt:Override Locale="de-at" Value="Erstellen oder Editieren von Code-Schnipseln"/>
+          <bt:Override Locale="es-ar" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-bo" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-cl" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-co" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-cr" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-do" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-ec" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-sv" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-gt" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-hn" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-mx" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-ni" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-pa" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-py" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-pe" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-pr" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-es" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-uy" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-mx" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="zh-cn" Value="创建或编辑代码段"/>
         </bt:String>
         <bt:String id="PG.CFCommand.Label" DefaultValue="Functions" />
         <bt:String id="PG.CFCommand.Title" DefaultValue="Functions" />
         <bt:String id="PG.CFCommand.TipTitle" DefaultValue="Launch the Custom Functions dashboard"></bt:String>
         <bt:String id="PG.RunCommand.Label" DefaultValue="Run">
-          <Override Locale="de-de" Value="Ausführen"/>
-          <Override Locale="de-ch" Value="Ausführen"/>
-          <Override Locale="de-at" Value="Ausführen"/>
-          <Override Locale="es-ar" Value="Ejecutar"/>
-          <Override Locale="es-bo" Value="Ejecutar"/>
-          <Override Locale="es-cl" Value="Ejecutar"/>
-          <Override Locale="es-co" Value="Ejecutar"/>
-          <Override Locale="es-cr" Value="Ejecutar"/>
-          <Override Locale="es-do" Value="Ejecutar"/>
-          <Override Locale="es-ec" Value="Ejecutar"/>
-          <Override Locale="es-sv" Value="Ejecutar"/>
-          <Override Locale="es-gt" Value="Ejecutar"/>
-          <Override Locale="es-hn" Value="Ejecutar"/>
-          <Override Locale="es-mx" Value="Ejecutar"/>
-          <Override Locale="es-ni" Value="Ejecutar"/>
-          <Override Locale="es-pa" Value="Ejecutar"/>
-          <Override Locale="es-py" Value="Ejecutar"/>
-          <Override Locale="es-pe" Value="Ejecutar"/>
-          <Override Locale="es-pr" Value="Ejecutar"/>
-          <Override Locale="es-es" Value="Ejecutar"/>
-          <Override Locale="es-uy" Value="Ejecutar"/>
-          <Override Locale="es-mx" Value="Ejecutar"/>
-          <Override Locale="zh-cn" Value="运行"/>
+          <bt:Override Locale="de-de" Value="Ausführen"/>
+          <bt:Override Locale="de-ch" Value="Ausführen"/>
+          <bt:Override Locale="de-at" Value="Ausführen"/>
+          <bt:Override Locale="es-ar" Value="Ejecutar"/>
+          <bt:Override Locale="es-bo" Value="Ejecutar"/>
+          <bt:Override Locale="es-cl" Value="Ejecutar"/>
+          <bt:Override Locale="es-co" Value="Ejecutar"/>
+          <bt:Override Locale="es-cr" Value="Ejecutar"/>
+          <bt:Override Locale="es-do" Value="Ejecutar"/>
+          <bt:Override Locale="es-ec" Value="Ejecutar"/>
+          <bt:Override Locale="es-sv" Value="Ejecutar"/>
+          <bt:Override Locale="es-gt" Value="Ejecutar"/>
+          <bt:Override Locale="es-hn" Value="Ejecutar"/>
+          <bt:Override Locale="es-mx" Value="Ejecutar"/>
+          <bt:Override Locale="es-ni" Value="Ejecutar"/>
+          <bt:Override Locale="es-pa" Value="Ejecutar"/>
+          <bt:Override Locale="es-py" Value="Ejecutar"/>
+          <bt:Override Locale="es-pe" Value="Ejecutar"/>
+          <bt:Override Locale="es-pr" Value="Ejecutar"/>
+          <bt:Override Locale="es-es" Value="Ejecutar"/>
+          <bt:Override Locale="es-uy" Value="Ejecutar"/>
+          <bt:Override Locale="es-mx" Value="Ejecutar"/>
+          <bt:Override Locale="zh-cn" Value="运行"/>
         </bt:String>
         <bt:String id="PG.RunCommand.Title" DefaultValue="Run">
-          <Override Locale="de-de" Value="Ausführen"/>
-          <Override Locale="de-ch" Value="Ausführen"/>
-          <Override Locale="de-at" Value="Ausführen"/>
-          <Override Locale="es-ar" Value="Ejecutar"/>
-          <Override Locale="es-bo" Value="Ejecutar"/>
-          <Override Locale="es-cl" Value="Ejecutar"/>
-          <Override Locale="es-co" Value="Ejecutar"/>
-          <Override Locale="es-cr" Value="Ejecutar"/>
-          <Override Locale="es-do" Value="Ejecutar"/>
-          <Override Locale="es-ec" Value="Ejecutar"/>
-          <Override Locale="es-sv" Value="Ejecutar"/>
-          <Override Locale="es-gt" Value="Ejecutar"/>
-          <Override Locale="es-hn" Value="Ejecutar"/>
-          <Override Locale="es-mx" Value="Ejecutar"/>
-          <Override Locale="es-ni" Value="Ejecutar"/>
-          <Override Locale="es-pa" Value="Ejecutar"/>
-          <Override Locale="es-py" Value="Ejecutar"/>
-          <Override Locale="es-pe" Value="Ejecutar"/>
-          <Override Locale="es-pr" Value="Ejecutar"/>
-          <Override Locale="es-es" Value="Ejecutar"/>
-          <Override Locale="es-uy" Value="Ejecutar"/>
-          <Override Locale="es-mx" Value="Ejecutar"/>
-          <Override Locale="zh-cn" Value="运行"/>
+          <bt:Override Locale="de-de" Value="Ausführen"/>
+          <bt:Override Locale="de-ch" Value="Ausführen"/>
+          <bt:Override Locale="de-at" Value="Ausführen"/>
+          <bt:Override Locale="es-ar" Value="Ejecutar"/>
+          <bt:Override Locale="es-bo" Value="Ejecutar"/>
+          <bt:Override Locale="es-cl" Value="Ejecutar"/>
+          <bt:Override Locale="es-co" Value="Ejecutar"/>
+          <bt:Override Locale="es-cr" Value="Ejecutar"/>
+          <bt:Override Locale="es-do" Value="Ejecutar"/>
+          <bt:Override Locale="es-ec" Value="Ejecutar"/>
+          <bt:Override Locale="es-sv" Value="Ejecutar"/>
+          <bt:Override Locale="es-gt" Value="Ejecutar"/>
+          <bt:Override Locale="es-hn" Value="Ejecutar"/>
+          <bt:Override Locale="es-mx" Value="Ejecutar"/>
+          <bt:Override Locale="es-ni" Value="Ejecutar"/>
+          <bt:Override Locale="es-pa" Value="Ejecutar"/>
+          <bt:Override Locale="es-py" Value="Ejecutar"/>
+          <bt:Override Locale="es-pe" Value="Ejecutar"/>
+          <bt:Override Locale="es-pr" Value="Ejecutar"/>
+          <bt:Override Locale="es-es" Value="Ejecutar"/>
+          <bt:Override Locale="es-uy" Value="Ejecutar"/>
+          <bt:Override Locale="es-mx" Value="Ejecutar"/>
+          <bt:Override Locale="zh-cn" Value="运行"/>
         </bt:String>
         <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Run the code snippet">
-          <Override Locale="de-de" Value="Code-Schnipsel ausführen"/>
-          <Override Locale="de-ch" Value="Code-Schnipsel ausführen"/>
-          <Override Locale="de-at" Value="Code-Schnipsel ausführen"/>
-          <Override Locale="es-ar" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-bo" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-cl" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-co" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-cr" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-do" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-ec" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-sv" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-gt" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-hn" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-mx" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-ni" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-pa" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-py" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-pe" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-pr" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-es" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-uy" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="es-mx" Value="Ejecuta el fragmento de código"/>
-          <Override Locale="zh-cn" Value="运行代码片段"/>
+          <bt:Override Locale="de-de" Value="Code-Schnipsel ausführen"/>
+          <bt:Override Locale="de-ch" Value="Code-Schnipsel ausführen"/>
+          <bt:Override Locale="de-at" Value="Code-Schnipsel ausführen"/>
+          <bt:Override Locale="es-ar" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-bo" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-cl" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-co" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-cr" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-do" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-ec" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-sv" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-gt" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-hn" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-mx" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-ni" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-pa" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-py" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-pe" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-pr" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-es" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-uy" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-mx" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="zh-cn" Value="运行代码片段"/>
         </bt:String>
         <bt:String id="PG.TutorialCommand.Label" DefaultValue="Tutorial" />
         <bt:String id="PG.TutorialCommand.TipTitle" DefaultValue="Script Lab tutorial">
-          <Override Locale="de-de" Value="Tutorial zu Script Lab"/>
-          <Override Locale="de-ch" Value="Tutorial zu Script Lab"/>
-          <Override Locale="de-at" Value="Tutorial zu Script Lab"/>
-          <Override Locale="es-ar" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-bo" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-cl" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-co" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-cr" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-do" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-ec" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-sv" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-gt" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-hn" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-mx" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-ni" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-pa" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-py" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-pe" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-pr" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-es" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-uy" Value="Tutorial de Script Lab"/>
-          <Override Locale="es-mx" Value="Tutorial de Script Lab"/>
-          <Override Locale="zh-cn" Value="Script Lab教程"/>
+          <bt:Override Locale="de-de" Value="Tutorial zu Script Lab"/>
+          <bt:Override Locale="de-ch" Value="Tutorial zu Script Lab"/>
+          <bt:Override Locale="de-at" Value="Tutorial zu Script Lab"/>
+          <bt:Override Locale="es-ar" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-bo" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-cl" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-co" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-cr" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-do" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-ec" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-sv" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-gt" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-hn" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-ni" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-pa" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-py" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-pe" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-pr" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-es" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-uy" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="zh-cn" Value="Script Lab教程"/>
         </bt:String>
         <bt:String id="PG.HelpCommand.Label" DefaultValue="Help">
-          <Override Locale="de-de" Value="Hilfe"/>
-          <Override Locale="de-ch" Value="Hilfe"/>
-          <Override Locale="de-at" Value="Hilfe"/>
-          <Override Locale="es-ar" Value="Ayuda"/>
-          <Override Locale="es-bo" Value="Ayuda"/>
-          <Override Locale="es-cl" Value="Ayuda"/>
-          <Override Locale="es-co" Value="Ayuda"/>
-          <Override Locale="es-cr" Value="Ayuda"/>
-          <Override Locale="es-do" Value="Ayuda"/>
-          <Override Locale="es-ec" Value="Ayuda"/>
-          <Override Locale="es-sv" Value="Ayuda"/>
-          <Override Locale="es-gt" Value="Ayuda"/>
-          <Override Locale="es-hn" Value="Ayuda"/>
-          <Override Locale="es-mx" Value="Ayuda"/>
-          <Override Locale="es-ni" Value="Ayuda"/>
-          <Override Locale="es-pa" Value="Ayuda"/>
-          <Override Locale="es-py" Value="Ayuda"/>
-          <Override Locale="es-pe" Value="Ayuda"/>
-          <Override Locale="es-pr" Value="Ayuda"/>
-          <Override Locale="es-es" Value="Ayuda"/>
-          <Override Locale="es-uy" Value="Ayuda"/>
-          <Override Locale="es-mx" Value="Ayuda"/>
-          <Override Locale="zh-cn" Value="帮助"/>
+          <bt:Override Locale="de-de" Value="Hilfe"/>
+          <bt:Override Locale="de-ch" Value="Hilfe"/>
+          <bt:Override Locale="de-at" Value="Hilfe"/>
+          <bt:Override Locale="es-ar" Value="Ayuda"/>
+          <bt:Override Locale="es-bo" Value="Ayuda"/>
+          <bt:Override Locale="es-cl" Value="Ayuda"/>
+          <bt:Override Locale="es-co" Value="Ayuda"/>
+          <bt:Override Locale="es-cr" Value="Ayuda"/>
+          <bt:Override Locale="es-do" Value="Ayuda"/>
+          <bt:Override Locale="es-ec" Value="Ayuda"/>
+          <bt:Override Locale="es-sv" Value="Ayuda"/>
+          <bt:Override Locale="es-gt" Value="Ayuda"/>
+          <bt:Override Locale="es-hn" Value="Ayuda"/>
+          <bt:Override Locale="es-mx" Value="Ayuda"/>
+          <bt:Override Locale="es-ni" Value="Ayuda"/>
+          <bt:Override Locale="es-pa" Value="Ayuda"/>
+          <bt:Override Locale="es-py" Value="Ayuda"/>
+          <bt:Override Locale="es-pe" Value="Ayuda"/>
+          <bt:Override Locale="es-pr" Value="Ayuda"/>
+          <bt:Override Locale="es-es" Value="Ayuda"/>
+          <bt:Override Locale="es-uy" Value="Ayuda"/>
+          <bt:Override Locale="es-mx" Value="Ayuda"/>
+          <bt:Override Locale="zh-cn" Value="帮助"/>
         </bt:String>
         <bt:String id="PG.HelpCommand.TipTitle" DefaultValue="Help for Script Lab">
-          <Override Locale="de-de" Value="Hilfe zu Script Lab"/>
-          <Override Locale="de-ch" Value="Hilfe zu Script Lab"/>
-          <Override Locale="de-at" Value="Hilfe zu Script Lab"/>
-          <Override Locale="es-ar" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-bo" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-cl" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-co" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-cr" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-do" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-ec" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-sv" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-gt" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-hn" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-mx" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-ni" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-pa" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-py" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-pe" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-pr" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-es" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-uy" Value="Ayuda de Script Lab"/>
-          <Override Locale="es-mx" Value="Ayuda de Script Lab"/>
-          <Override Locale="zh-cn" Value="帮助Script Lab"/>
+          <bt:Override Locale="de-de" Value="Hilfe zu Script Lab"/>
+          <bt:Override Locale="de-ch" Value="Hilfe zu Script Lab"/>
+          <bt:Override Locale="de-at" Value="Hilfe zu Script Lab"/>
+          <bt:Override Locale="es-ar" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-bo" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-cl" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-co" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-cr" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-do" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-ec" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-sv" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-gt" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-hn" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-ni" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-pa" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-py" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-pe" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-pr" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-es" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-uy" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="zh-cn" Value="帮助Script Lab"/>
         </bt:String>
         <bt:String id="PG.ApiDocsCommand.Label" DefaultValue="Reference Docs">
-          <Override Locale="de-de" Value="Dokumentation"/>
-          <Override Locale="de-ch" Value="Dokumentation"/>
-          <Override Locale="de-at" Value="Dokumentation"/>
-          <Override Locale="es-ar" Value="Documentación"/>
-          <Override Locale="es-bo" Value="Documentación"/>
-          <Override Locale="es-cl" Value="Documentación"/>
-          <Override Locale="es-co" Value="Documentación"/>
-          <Override Locale="es-cr" Value="Documentación"/>
-          <Override Locale="es-do" Value="Documentación"/>
-          <Override Locale="es-ec" Value="Documentación"/>
-          <Override Locale="es-sv" Value="Documentación"/>
-          <Override Locale="es-gt" Value="Documentación"/>
-          <Override Locale="es-hn" Value="Documentación"/>
-          <Override Locale="es-mx" Value="Documentación"/>
-          <Override Locale="es-ni" Value="Documentación"/>
-          <Override Locale="es-pa" Value="Documentación"/>
-          <Override Locale="es-py" Value="Documentación"/>
-          <Override Locale="es-pe" Value="Documentación"/>
-          <Override Locale="es-pr" Value="Documentación"/>
-          <Override Locale="es-es" Value="Documentación"/>
-          <Override Locale="es-uy" Value="Documentación"/>
-          <Override Locale="es-mx" Value="Documentación"/>
-          <Override Locale="zh-cn" Value="参考文档"/>
+          <bt:Override Locale="de-de" Value="Dokumentation"/>
+          <bt:Override Locale="de-ch" Value="Dokumentation"/>
+          <bt:Override Locale="de-at" Value="Dokumentation"/>
+          <bt:Override Locale="es-ar" Value="Documentación"/>
+          <bt:Override Locale="es-bo" Value="Documentación"/>
+          <bt:Override Locale="es-cl" Value="Documentación"/>
+          <bt:Override Locale="es-co" Value="Documentación"/>
+          <bt:Override Locale="es-cr" Value="Documentación"/>
+          <bt:Override Locale="es-do" Value="Documentación"/>
+          <bt:Override Locale="es-ec" Value="Documentación"/>
+          <bt:Override Locale="es-sv" Value="Documentación"/>
+          <bt:Override Locale="es-gt" Value="Documentación"/>
+          <bt:Override Locale="es-hn" Value="Documentación"/>
+          <bt:Override Locale="es-mx" Value="Documentación"/>
+          <bt:Override Locale="es-ni" Value="Documentación"/>
+          <bt:Override Locale="es-pa" Value="Documentación"/>
+          <bt:Override Locale="es-py" Value="Documentación"/>
+          <bt:Override Locale="es-pe" Value="Documentación"/>
+          <bt:Override Locale="es-pr" Value="Documentación"/>
+          <bt:Override Locale="es-es" Value="Documentación"/>
+          <bt:Override Locale="es-uy" Value="Documentación"/>
+          <bt:Override Locale="es-mx" Value="Documentación"/>
+          <bt:Override Locale="zh-cn" Value="参考文档"/>
         </bt:String>
         <bt:String id="PG.ApiDocsCommand.TipTitle" DefaultValue="API Reference Documentation">
-          <Override Locale="de-de" Value="API-Dokumentation"/>
-          <Override Locale="de-ch" Value="API-Dokumentation"/>
-          <Override Locale="de-at" Value="API-Dokumentation"/>
-          <Override Locale="es-ar" Value="Documentación de la API"/>
-          <Override Locale="es-bo" Value="Documentación de la API"/>
-          <Override Locale="es-cl" Value="Documentación de la API"/>
-          <Override Locale="es-co" Value="Documentación de la API"/>
-          <Override Locale="es-cr" Value="Documentación de la API"/>
-          <Override Locale="es-do" Value="Documentación de la API"/>
-          <Override Locale="es-ec" Value="Documentación de la API"/>
-          <Override Locale="es-sv" Value="Documentación de la API"/>
-          <Override Locale="es-gt" Value="Documentación de la API"/>
-          <Override Locale="es-hn" Value="Documentación de la API"/>
-          <Override Locale="es-mx" Value="Documentación de la API"/>
-          <Override Locale="es-ni" Value="Documentación de la API"/>
-          <Override Locale="es-pa" Value="Documentación de la API"/>
-          <Override Locale="es-py" Value="Documentación de la API"/>
-          <Override Locale="es-pe" Value="Documentación de la API"/>
-          <Override Locale="es-pr" Value="Documentación de la API"/>
-          <Override Locale="es-es" Value="Documentación de la API"/>
-          <Override Locale="es-uy" Value="Documentación de la API"/>
-          <Override Locale="es-mx" Value="Documentación de la API"/>
-          <Override Locale="zh-cn" Value="API参考文案"/>
+          <bt:Override Locale="de-de" Value="API-Dokumentation"/>
+          <bt:Override Locale="de-ch" Value="API-Dokumentation"/>
+          <bt:Override Locale="de-at" Value="API-Dokumentation"/>
+          <bt:Override Locale="es-ar" Value="Documentación de la API"/>
+          <bt:Override Locale="es-bo" Value="Documentación de la API"/>
+          <bt:Override Locale="es-cl" Value="Documentación de la API"/>
+          <bt:Override Locale="es-co" Value="Documentación de la API"/>
+          <bt:Override Locale="es-cr" Value="Documentación de la API"/>
+          <bt:Override Locale="es-do" Value="Documentación de la API"/>
+          <bt:Override Locale="es-ec" Value="Documentación de la API"/>
+          <bt:Override Locale="es-sv" Value="Documentación de la API"/>
+          <bt:Override Locale="es-gt" Value="Documentación de la API"/>
+          <bt:Override Locale="es-hn" Value="Documentación de la API"/>
+          <bt:Override Locale="es-mx" Value="Documentación de la API"/>
+          <bt:Override Locale="es-ni" Value="Documentación de la API"/>
+          <bt:Override Locale="es-pa" Value="Documentación de la API"/>
+          <bt:Override Locale="es-py" Value="Documentación de la API"/>
+          <bt:Override Locale="es-pe" Value="Documentación de la API"/>
+          <bt:Override Locale="es-pr" Value="Documentación de la API"/>
+          <bt:Override Locale="es-es" Value="Documentación de la API"/>
+          <bt:Override Locale="es-uy" Value="Documentación de la API"/>
+          <bt:Override Locale="es-mx" Value="Documentación de la API"/>
+          <bt:Override Locale="zh-cn" Value="API参考文案"/>
         </bt:String>
         <bt:String id="PG.AskCommand.Label" DefaultValue="Ask the Community">
-          <Override Locale="de-de" Value="Community"/>
-          <Override Locale="de-ch" Value="Community"/>
-          <Override Locale="de-at" Value="Community"/>
-          <Override Locale="es-ar" Value="Comunidad"/>
-          <Override Locale="es-bo" Value="Comunidad"/>
-          <Override Locale="es-cl" Value="Comunidad"/>
-          <Override Locale="es-co" Value="Comunidad"/>
-          <Override Locale="es-cr" Value="Comunidad"/>
-          <Override Locale="es-do" Value="Comunidad"/>
-          <Override Locale="es-ec" Value="Comunidad"/>
-          <Override Locale="es-sv" Value="Comunidad"/>
-          <Override Locale="es-gt" Value="Comunidad"/>
-          <Override Locale="es-hn" Value="Comunidad"/>
-          <Override Locale="es-mx" Value="Comunidad"/>
-          <Override Locale="es-ni" Value="Comunidad"/>
-          <Override Locale="es-pa" Value="Comunidad"/>
-          <Override Locale="es-py" Value="Comunidad"/>
-          <Override Locale="es-pe" Value="Comunidad"/>
-          <Override Locale="es-pr" Value="Comunidad"/>
-          <Override Locale="es-es" Value="Comunidad"/>
-          <Override Locale="es-uy" Value="Comunidad"/>
-          <Override Locale="es-mx" Value="Comunidad"/>
-          <Override Locale="zh-cn" Value="问社区"/>
+          <bt:Override Locale="de-de" Value="Community"/>
+          <bt:Override Locale="de-ch" Value="Community"/>
+          <bt:Override Locale="de-at" Value="Community"/>
+          <bt:Override Locale="es-ar" Value="Comunidad"/>
+          <bt:Override Locale="es-bo" Value="Comunidad"/>
+          <bt:Override Locale="es-cl" Value="Comunidad"/>
+          <bt:Override Locale="es-co" Value="Comunidad"/>
+          <bt:Override Locale="es-cr" Value="Comunidad"/>
+          <bt:Override Locale="es-do" Value="Comunidad"/>
+          <bt:Override Locale="es-ec" Value="Comunidad"/>
+          <bt:Override Locale="es-sv" Value="Comunidad"/>
+          <bt:Override Locale="es-gt" Value="Comunidad"/>
+          <bt:Override Locale="es-hn" Value="Comunidad"/>
+          <bt:Override Locale="es-mx" Value="Comunidad"/>
+          <bt:Override Locale="es-ni" Value="Comunidad"/>
+          <bt:Override Locale="es-pa" Value="Comunidad"/>
+          <bt:Override Locale="es-py" Value="Comunidad"/>
+          <bt:Override Locale="es-pe" Value="Comunidad"/>
+          <bt:Override Locale="es-pr" Value="Comunidad"/>
+          <bt:Override Locale="es-es" Value="Comunidad"/>
+          <bt:Override Locale="es-uy" Value="Comunidad"/>
+          <bt:Override Locale="es-mx" Value="Comunidad"/>
+          <bt:Override Locale="zh-cn" Value="问社区"/>
         </bt:String>
         <bt:String id="PG.AskCommand.TipTitle" DefaultValue="Get API help from the community">
-          <Override Locale="de-de" Value="Unterstützung durch die Community"/>
-          <Override Locale="de-ch" Value="Unterstützung durch die Community"/>
-          <Override Locale="de-at" Value="Unterstützung durch die Community"/>
-          <Override Locale="es-ar" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-bo" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-cl" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-co" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-cr" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-do" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-ec" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-sv" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-gt" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-hn" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-mx" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-ni" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-pa" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-py" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-pe" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-pr" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-es" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-uy" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="es-mx" Value="Obtén ayuda de nuestra comunidad"/>
-          <Override Locale="zh-cn" Value="从社区获取API帮助"/>
+          <bt:Override Locale="de-de" Value="Unterstützung durch die Community"/>
+          <bt:Override Locale="de-ch" Value="Unterstützung durch die Community"/>
+          <bt:Override Locale="de-at" Value="Unterstützung durch die Community"/>
+          <bt:Override Locale="es-ar" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-bo" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-cl" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-co" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-cr" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-do" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-ec" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-sv" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-gt" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-hn" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-mx" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-ni" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-pa" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-py" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-pe" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-pr" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-es" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-uy" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-mx" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="zh-cn" Value="从社区获取API帮助"/>
         </bt:String>
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="PG.CodeSupertip.Desc" DefaultValue="Opens the Script Lab code editor">
-          <Override Locale="de-de" Value="Den Script Lab Code-Editor aufrufen."/>
-          <Override Locale="de-ch" Value="Den Script Lab Code-Editor aufrufen."/>
-          <Override Locale="de-at" Value="Den Script Lab Code-Editor aufrufen."/>
-          <Override Locale="es-ar" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-bo" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-cl" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-co" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-cr" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-do" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-ec" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-sv" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-gt" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-hn" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-mx" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-ni" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-pa" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-py" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-pe" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-pr" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-es" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-uy" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="es-mx" Value="Abre el editor de código de Script Lab."/>
-          <Override Locale="zh-cn" Value="打开Script Lab代码编辑器"/>
+          <bt:Override Locale="de-de" Value="Den Script Lab Code-Editor aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Den Script Lab Code-Editor aufrufen."/>
+          <bt:Override Locale="de-at" Value="Den Script Lab Code-Editor aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-bo" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-cl" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-co" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-cr" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-do" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-ec" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-sv" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-gt" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-hn" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-ni" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-pa" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-py" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-pe" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-pr" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-es" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-uy" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="zh-cn" Value="打开Script Lab代码编辑器"/>
         </bt:String>
         <bt:String id="PG.CFSupertip.Desc" DefaultValue="Launch the Custom Functions dashboard"></bt:String>
         <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet">
-          <Override Locale="de-de" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
-          <Override Locale="de-ch" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
-          <Override Locale="de-at" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
-          <Override Locale="es-ar" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-bo" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-cl" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-co" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-cr" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-do" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-ec" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-sv" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-gt" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-hn" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-mx" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-ni" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-pa" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-py" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-pe" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-pr" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-es" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-uy" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="es-mx" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <Override Locale="zh-cn" Value="打开运行当前代码段的任务窗格"/>
+          <bt:Override Locale="de-de" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
+          <bt:Override Locale="de-at" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-bo" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-cl" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-co" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-cr" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-do" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-ec" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-sv" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-gt" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-hn" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-mx" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-ni" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-pa" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-py" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-pe" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-pr" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-es" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-uy" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-mx" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="zh-cn" Value="打开运行当前代码段的任务窗格"/>
         </bt:String>
         <bt:String id="PG.TutorialCommand.Desc" DefaultValue="Launches a quick Script Lab tutorial">
-          <Override Locale="de-de" Value="Ein Tutorial zu Script Lab aufrufen."/>
-          <Override Locale="de-ch" Value="Ein Tutorial zu Script Lab aufrufen."/>
-          <Override Locale="de-at" Value="Ein Tutorial zu Script Lab aufrufen."/>
-          <Override Locale="es-ar" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-bo" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-cl" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-co" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-cr" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-do" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-ec" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-sv" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-gt" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-hn" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-mx" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-ni" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-pa" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-py" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-pe" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-pr" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-es" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-uy" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="es-mx" Value="Abre un breve tutorial de Script Lab."/>
-          <Override Locale="zh-cn" Value="快速启动Script Lab教程"/>
+          <bt:Override Locale="de-de" Value="Ein Tutorial zu Script Lab aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Ein Tutorial zu Script Lab aufrufen."/>
+          <bt:Override Locale="de-at" Value="Ein Tutorial zu Script Lab aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-bo" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-cl" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-co" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-cr" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-do" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-ec" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-sv" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-gt" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-hn" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-ni" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-pa" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-py" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-pe" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-pr" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-es" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-uy" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="zh-cn" Value="快速启动Script Lab教程"/>
         </bt:String>
         <bt:String id="PG.HelpCommand.Desc" DefaultValue="Launches documentation on using Script Lab">
-          <Override Locale="de-de" Value="Die Dokumentation zu Script Lab aufrufen."/>
-          <Override Locale="de-ch" Value="Die Dokumentation zu Script Lab aufrufen."/>
-          <Override Locale="de-at" Value="Die Dokumentation zu Script Lab aufrufen."/>
-          <Override Locale="es-ar" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-bo" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-cl" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-co" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-cr" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-do" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-ec" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-sv" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-gt" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-hn" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-mx" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-ni" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-pa" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-py" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-pe" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-pr" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-es" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-uy" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="es-mx" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <Override Locale="zh-cn" Value="使用Script Lab发布文档"/>
+          <bt:Override Locale="de-de" Value="Die Dokumentation zu Script Lab aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Die Dokumentation zu Script Lab aufrufen."/>
+          <bt:Override Locale="de-at" Value="Die Dokumentation zu Script Lab aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-bo" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-cl" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-co" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-cr" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-do" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-ec" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-sv" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-gt" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-hn" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-ni" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-pa" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-py" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-pe" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-pr" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-es" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-uy" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="zh-cn" Value="使用Script Lab发布文档"/>
         </bt:String>
         <bt:String id="PG.ApiDocsCommand.Desc" DefaultValue="Opens the API documentation for the Office application that you are running">
-          <Override Locale="de-de" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
-          <Override Locale="de-ch" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
-          <Override Locale="de-at" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
-          <Override Locale="es-ar" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-bo" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-cl" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-co" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-cr" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-do" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-ec" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-sv" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-gt" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-hn" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-mx" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-ni" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-pa" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-py" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-pe" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-pr" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-es" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-uy" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="es-mx" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <Override Locale="zh-cn" Value="打开正在运行的Office应用程序的API文档"/>
+          <bt:Override Locale="de-de" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
+          <bt:Override Locale="de-at" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-bo" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-cl" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-co" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-cr" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-do" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-ec" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-sv" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-gt" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-hn" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-mx" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-ni" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-pa" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-py" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-pe" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-pr" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-es" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-uy" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-mx" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="zh-cn" Value="打开正在运行的Office应用程序的API文档"/>
         </bt:String>
         <bt:String id="PG.AskCommand.Desc" DefaultValue="Launches a community forum for questions about the Office JavaScript APIs">
-          <Override Locale="de-de" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
-          <Override Locale="de-ch" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
-          <Override Locale="de-at" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
-          <Override Locale="es-ar" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-bo" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-cl" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-co" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-cr" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-do" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-ec" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-sv" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-gt" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-hn" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-mx" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-ni" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-pa" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-py" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-pe" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-pr" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-es" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-uy" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="es-mx" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <Override Locale="zh-cn" Value="启动一个社区论坛，讨论有关Office JavaScript API的问题"/>
+          <bt:Override Locale="de-de" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
+          <bt:Override Locale="de-at" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-bo" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-cl" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-co" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-cr" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-do" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-ec" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-sv" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-gt" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-hn" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-mx" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-ni" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-pa" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-py" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-pe" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-pr" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-es" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-uy" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-mx" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="zh-cn" Value="启动一个社区论坛，讨论有关Office JavaScript API的问题"/>
         </bt:String>
         <bt:String id="PG.Description" DefaultValue="Code, run, and share your Add-in snippets directly from Office.">
-          <Override Locale="de-de" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
-          <Override Locale="de-ch" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
-          <Override Locale="de-at" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
-          <Override Locale="es-ar" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-bo" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-cl" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-co" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-cr" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-do" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-ec" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-sv" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-gt" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-hn" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-mx" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-ni" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-pa" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-py" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-pe" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-pr" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-es" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-uy" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="es-mx" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <Override Locale="zh-cn" Value="直接从Office中编码、运行和共享附加代码片段。"/>
+          <bt:Override Locale="de-de" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
+          <bt:Override Locale="de-ch" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
+          <bt:Override Locale="de-at" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
+          <bt:Override Locale="es-ar" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-bo" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-cl" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-co" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-cr" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-do" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-ec" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-sv" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-gt" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-hn" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-mx" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-ni" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-pa" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-py" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-pe" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-pr" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-es" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-uy" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-mx" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="zh-cn" Value="直接从Office中编码、运行和共享附加代码片段。"/>
         </bt:String>
       </bt:LongStrings>
     </Resources>


### PR DESCRIPTION
## Description
I've noticed that Script Lab's manifest does not conform to Office Add-ins manifest schema because of missing Basic Types prefixes in resources overrides.

This is to fix it. 

## Related Issue
[script-lab-prod.xml manifest fails Office add-in manifest check](https://github.com/OfficeDev/script-lab/issues/831)

## Motivation and Context
Script Lab manifest, as it is, will not pass through Office add-ins validation when resubmitted next time. This changes makes it conform to the schema.

## How Has This Been Tested?
Confirmed with [Office Add-in Validator](https://github.com/OfficeDev/office-addin-validator) that the updated manifest passes the checks.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/754611/41239217-c8b702a0-6d8f-11e8-8e65-c546893bfe70.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
