### PR TITLE
Add test coverage measures and output for unit tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,8 @@
     "start": "set HTTPS=false&&react-scripts-ts start",
     "build": "react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom",
-    "test-coverage": "yarn test -- --coverage && coverage\\lcov-report\\index.html",
+    "test-coverage": "yarn test -- --coverage",
+    "show-coverage": "yarn test-coverage && coverage\\lcov-report\\index.html",
     "eject": "react-scripts-ts eject",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
@@ -42,8 +43,9 @@
       "office-ui-fabric-react/lib/": "office-ui-fabric-react/lib-commonjs/"
     },
     "collectCoverageFrom": [
-      "src/**/*.(?<!d.)ts",
-      "src/**/*.tsx"
+      "src/**/*.ts",
+      "src/**/*.tsx",
+      "!src/**/*.d.ts"
     ], 
     "coverageReporters": [
       "json",


### PR DESCRIPTION
This lets us run unit tests with 'yarn test-coverage' and see what product code is and isn't tested. For reference, the current overall coverage (summary from a run) is:
======== Coverage summary ==============
Statements   : 9.67% ( 65/672 )
Branches     : 6.49% ( 17/262 )
Functions    : 6.79% ( 11/162 )
Lines        : 9.49% ( 56/590 )
===================================

I had to add the files to be covered using an awkward regex because react-scripts-ts does not support jest's coveragePathIgnorePatterns setting. If it did, I could just put *.d.ts there and call it a day. 

I don't need to explicitly exclude *.test.ts files since they are already understood to not be included in the coverage.

The output report (broken down by coverage of each of the 4 categories) is an html page that provides a tree summary of each directory, subdirectory, etc, down to individual files. The individual files show visual coverage markup. The entrypoint is an html page, located at <root>/coverage/lcov-report/index.html

I currently have the page pop up automatically after the run, but I can pull that out if it seems annoying.