### PR TITLE
removed path-to-regexp dependency

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -13,7 +13,6 @@
     "monaco-editor": "^0.13.1",
     "normalizr": "^3.2.4",
     "office-ui-fabric-react": "^6.73.0",
-    "path-to-regexp": "^2.2.1",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-redux": "^5.0.7",


### PR DESCRIPTION
Per a comment from Nico offline, path-to-regexp is no longer necessary, so removing from the editor's package.json