### PR TITLE
Update monaco-editor to 0.14.3

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -10,7 +10,7 @@
     "core-js": "^2.5.7",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.10",
-    "monaco-editor": "^0.13.1",
+    "monaco-editor": "^0.14.3",
     "normalizr": "^3.2.4",
     "office-ui-fabric-react": "6.79.0",
     "react": "^16.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6449,9 +6449,9 @@ moment@^2.21.0:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
-monaco-editor@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.13.1.tgz#6b9ce20e4d1c945042d256825eb133cb23315a52"
+monaco-editor@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.14.3.tgz#7cc4a4096a3821f52fea9b10489b527ef3034e22"
 
 moo@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
Fixes #128 by bringing in updated monaco-editor themes that pass high-contrast MAS guidelines.
See bug for details. 

There were some issues with updating monaco-editor versions before, but this passes basic smoke tests so far. 