### PR TITLE
Show an error when logging into GitHub in IE.

### DIFF
--- a/packages/editor/src/store/github/sagas.ts
+++ b/packages/editor/src/store/github/sagas.ts
@@ -7,9 +7,17 @@ import { fetchAllGistMetadataSaga } from '../gists/sagas'
 import selectors from '../selectors'
 
 function* gitHubLoginSaga(action: ActionType<typeof github.login.request>) {
-  const profile = yield call(login)
-
-  yield put(github.login.success(profile))
+  if ((document as any).documentMode) {
+    // if we are in IE
+    yield put(
+      github.login.failure(
+        new Error('GitHub login is not supported in Internet Explorer'),
+      ),
+    )
+  } else {
+    const profile = yield call(login)
+    yield put(github.login.success(profile))
+  }
 }
 
 function* gitHubLogoutSaga(action: ActionType<typeof github.logout.request>) {
@@ -18,8 +26,13 @@ function* gitHubLogoutSaga(action: ActionType<typeof github.logout.request>) {
   yield put(github.logout.success())
 }
 
+function* gitHubLoginFailureSaga(action: ActionType<typeof github.login.failure>) {
+  console.log(action.payload.message) // - how do we actually show this
+}
+
 export default function* githubWatcher() {
   yield takeEvery(getType(github.login.request), gitHubLoginSaga)
   yield takeEvery(getType(github.login.success), fetchAllGistMetadataSaga)
   yield takeEvery(getType(github.logout.request), gitHubLogoutSaga)
+  yield takeEvery(getType(github.login.failure), gitHubLoginFailureSaga)
 }


### PR DESCRIPTION
Proposing this as the experience for IE GitHub login.
We can tell when we are in IE, and we can complete the login experience with a failure.
We would then just need to show the error, and we can put text in there about the PAT workaround?

Followup: how do we show a modal dialog in this codebase?