### PR TITLE
Runs a `git diff-index` after postinstall to ensure clean status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache: yarn
 install:
   - yarn install --frozen-lockfile
   - yarn postinstall
+  - git diff-index HEAD --name-status # This makes sure that someone ran "yarn install" after merging their PR, and that the postinstall doesn't produce any diffs, which are annoying/confusing
 
 before_script:
   - yarn prettier

--- a/packages/editor/public/heartbeat.html
+++ b/packages/editor/public/heartbeat.html
@@ -23,7 +23,7 @@
     <noscript> You need to enable JavaScript to run this app. </noscript>
 
     <!-- Begin precompile placeholder: heartbeat.js -->
-    <script src="/precompiled/heartbeat-99f80878e2905f3bfcbfdfd8f8ec8a04.js"></script>
+    <script src="/precompiled/heartbeat-5e096629c7356dd459c0e0180924060f.js"></script>
     <!-- End precompile placeholder: heartbeat.js -->
   </body>
 </html>

--- a/packages/editor/public/run.html
+++ b/packages/editor/public/run.html
@@ -43,7 +43,7 @@
     </div>
 
     <!-- Begin precompile placeholder: run-page-redirect.js -->
-    <script src="/precompiled/run-page-redirect-bb35a9fffa22debff8d60191baadc541.js"></script>
+    <script src="/precompiled/run-page-redirect-cbf35330fce6f26ab2d6a8440eaaa30c.js"></script>
     <!-- End precompile placeholder: run-page-redirect.js -->
   </body>
 </html>


### PR DESCRIPTION
That way, others won't end up with differences in html pages due to postinstall producing a different hash (caused by a merge without a `yarn postinstall` run)