### PR TITLE
Allow "office.experimental.js" in libraries

### DIFF
--- a/packages/common/src/utilities/process.libraries.ts
+++ b/packages/common/src/utilities/process.libraries.ts
@@ -45,7 +45,18 @@ export default function processLibraries(
        * it is special because of how it needs to be *outside* of the iframe,
        * whereas the rest of the script references need to be inside the iframe.
        */
-      if (/(?:office|office.debug).js$/.test(resolvedUrlPath.toLowerCase())) {
+      const officeJsRegex = /.*office(\.(experimental))?(\.debug)?\.js$/;
+      /* captures:
+          https://office.js
+          https://office.debug.js
+          https://office.experimental.js
+          https://office.experimental.debug.js
+        fails on:
+          https://office.fooooo.debug.js
+          https://officedebug.js
+          https://officeydebug.js
+      */
+      if (officeJsRegex.test(resolvedUrlPath.toLowerCase())) {
         officeJs = resolvedUrlPath;
         return null;
       }

--- a/packages/editor/public/custom-functions-heartbeat.html
+++ b/packages/editor/public/custom-functions-heartbeat.html
@@ -18,7 +18,7 @@
     <noscript> You need to enable JavaScript to run this app. </noscript>
 
     <!-- Begin precompile placeholder: custom-functions-heartbeat.js -->
-    <script src="/precompiled/custom-functions-heartbeat-6dfd49f85e5faa3d5f885e72e4c677ed.js"></script>
+    <script src="/precompiled/custom-functions-heartbeat-9e271569c5f6611fa2e1bf1f81c2a92e.js"></script>
     <!-- End precompile placeholder: custom-functions-heartbeat.js -->
   </body>
 </html>


### PR DESCRIPTION
Porting over this logic, which had been introduced in the older Script Lab 2017 as part of https://github.com/OfficeDev/script-lab-2017/commit/430f1b29f9aa10e6e98fce8b9007f84164c0de7b#diff-47e573fd13de9e3328c8c558d2e890b0