### PR TITLE
Remove search when no samples

### DIFF
--- a/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 
+import Only from 'common/lib/components/Only';
+
 import Content from '../Content';
 import GalleryList from '../GalleryList';
 import { SearchBox } from 'office-ui-fabric-react/lib/components/SearchBox';
@@ -42,11 +44,14 @@ class Samples extends Component<IProps, IState> {
         title="Samples"
         description="Choose one of the samples below to get started."
       >
-        <SearchBox
-          data-testid="samples-search"
-          placeholder="Search our samples"
-          onChange={this.setFilterQuery}
-        />
+        <Only when={Object.keys(samplesByGroup).length > 0}>
+          <SearchBox
+            data-testid="samples-search"
+            placeholder="Search our samples"
+            onChange={this.setFilterQuery}
+          />
+        </Only>
+
         {Object.keys(filteredSamplesByGroup).length > 0 ? (
           Object.keys(filteredSamplesByGroup)
             .map(group =>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35939126/51274514-407fb700-1984-11e9-945e-ff9a69b97fa6.png)
Because ^ that looks weird.