### PR TITLE
Re-port code that got lost in earlier merge.

### DIFF
--- a/packages/editor/src/pages/Editor/store/misc/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/misc/sagas.ts
@@ -11,6 +11,7 @@ import {
 import ensureFreshLocalStorage from 'common/lib/utilities/ensure.fresh.local.storage';
 import { localStorageKeys } from 'common/lib/constants';
 import { showSplashScreen } from 'common/lib/utilities/splash.screen';
+import { MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
 
 export default function* miscWatcher() {
   yield takeEvery(getType(actions.misc.initialize), onInitializeSaga);
@@ -94,8 +95,28 @@ function* onConfirmSwitchEnvironmentSaga(
 }
 
 function* onPopOutEditorSaga() {
-  Office.context.ui.displayDialogAsync(window.location.href);
-  window.location.href = currentRunnerUrl;
+  Office.context.ui.displayDialogAsync(
+    window.location.href,
+    { height: 60, width: 60, promptBeforeOpen: false },
+    (result: Office.AsyncResult<any>) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        window.location.href = currentRunnerUrl;
+      } else {
+        console.error(result);
+        actions.messageBar.show({
+          text: 'Could not open a standalone code editor window.',
+          style: MessageBarType.error,
+          button: {
+            text: 'More info',
+            action: actions.messageBar.show({
+              text: result.error.message,
+              style: MessageBarType.error,
+            }),
+          },
+        });
+      }
+    },
+  );
 }
 
 function* onGoToCustomFunctionsSaga() {

--- a/packages/editor/src/pages/Editor/store/misc/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/misc/sagas.ts
@@ -1,4 +1,4 @@
-import { takeEvery, put, call, select } from 'redux-saga/effects';
+import { takeEvery, put, select } from 'redux-saga/effects';
 import { getType, ActionType } from 'typesafe-actions';
 import { actions, selectors } from '../../store';
 import {
@@ -10,8 +10,11 @@ import {
 } from 'common/lib/environment';
 import ensureFreshLocalStorage from 'common/lib/utilities/ensure.fresh.local.storage';
 import { localStorageKeys } from 'common/lib/constants';
-import { showSplashScreen } from 'common/lib/utilities/splash.screen';
-import { MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
+import {
+  showSplashScreen,
+  invokeGlobalErrorHandler,
+} from 'common/lib/utilities/splash.screen';
+import { ScriptLabError } from 'common/lib/utilities/error';
 
 export default function* miscWatcher() {
   yield takeEvery(getType(actions.misc.initialize), onInitializeSaga);
@@ -103,17 +106,12 @@ function* onPopOutEditorSaga() {
         window.location.href = currentRunnerUrl;
       } else {
         console.error(result);
-        actions.messageBar.show({
-          text: 'Could not open a standalone code editor window.',
-          style: MessageBarType.error,
-          button: {
-            text: 'More info',
-            action: actions.messageBar.show({
-              text: result.error.message,
-              style: MessageBarType.error,
-            }),
-          },
-        });
+        invokeGlobalErrorHandler(
+          new ScriptLabError(
+            'Could not open a standalone code editor window.',
+            new Error(result.error.message),
+          ),
+        );
       }
     },
   );


### PR DESCRIPTION
Originally from commit f84795e59e67b686dd5b3436718ded66f869ac74,
"Merge pull request #540 from OfficeDev/annich/fixDialogs"
hide pop-out editor for non-outlook desktop and make the window smaller