### PR TITLE
Search improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,6 +65,7 @@
     "stylesheet",
     "subfolders",
     "taskpane",
+    "testid",
     "typesafe",
     "uncomment",
     "uniquify",

--- a/packages/common/src/utilities/string.ts
+++ b/packages/common/src/utilities/string.ts
@@ -1,5 +1,24 @@
 import { ScriptLabError } from './error';
 
+export function matchesSearch(
+  queryLowercase: string,
+  texts: Array<string | null>,
+): boolean {
+  if (queryLowercase.length === 0) {
+    return true;
+  }
+
+  for (const item of texts) {
+    if (item) {
+      if (item.toLowerCase().includes(queryLowercase)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 // tslint:disable
 export function stripSpaces(text: string) {
   let lines: string[] = text.split('\n');

--- a/packages/editor/src/pages/Editor/components/Backstage/MySolutions/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/MySolutions/index.tsx
@@ -85,16 +85,12 @@ class MySolutions extends React.Component<IProps> {
                 return true;
               }
 
-              const megastring = [
-                solution.id,
-                solution.name,
-                solution.description,
-                ...solution.files.map(file => file.content),
-              ]
+              const megaString = [solution.name, solution.description]
                 .filter(Boolean)
-                .join(' ');
+                .join(' ')
+                .toLowerCase();
 
-              return megastring.includes(this.state.filterQuery);
+              return megaString.includes(this.state.filterQuery.toLowerCase());
             })
             .map(sol => ({
               key: sol.id,
@@ -119,11 +115,12 @@ class MySolutions extends React.Component<IProps> {
                   return true;
                 }
 
-                const megastring = [meta.title, meta.description]
+                const megaString = [meta.title, meta.description]
                   .filter(Boolean)
-                  .join(' ');
+                  .join(' ')
+                  .toLowerCase();
 
-                return megastring.includes(this.state.filterQuery);
+                return megaString.includes(this.state.filterQuery.toLowerCase());
               })
               .map(gist => ({
                 key: gist.id,

--- a/packages/editor/src/pages/Editor/components/Backstage/MySolutions/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/MySolutions/index.tsx
@@ -5,6 +5,7 @@ import { Label } from 'office-ui-fabric-react/lib/Label';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
 
 import Only from 'common/lib/components/Only';
+import { matchesSearch } from 'common/lib/utilities/string';
 
 import Content from '../Content';
 import GalleryList from '../GalleryList';
@@ -22,23 +23,20 @@ interface IProps {
 }
 
 interface IState {
-  filterQuery: string;
+  filterQueryLowercase: string;
   localStorageWarningIsVisible: boolean;
 }
 
 class MySolutions extends React.Component<IProps> {
   state: IState = {
-    filterQuery: '',
+    filterQueryLowercase: '',
     localStorageWarningIsVisible: !localStorage.getItem(
       localStorageKeyHasDismissedWarning,
     ),
   };
 
-  componentWillMount() {
-    this.setFilterQuery('');
-  }
-
-  setFilterQuery = (filterQuery: string) => this.setState({ filterQuery });
+  setFilterQuery = (filterQuery: string) =>
+    this.setState({ filterQueryLowercase: filterQuery.toLowerCase() });
 
   hideLocalStorageWarning = () => {
     this.setState({ localStorageWarningIsVisible: false }, () =>
@@ -80,24 +78,15 @@ class MySolutions extends React.Component<IProps> {
             </Only>
           }
           items={solutions
-            .filter(solution => {
-              if (this.state.filterQuery === '') {
-                return true;
-              }
-
-              const megaString = [
+            .filter(solution =>
+              matchesSearch(this.state.filterQueryLowercase, [
                 process.env.NODE_ENV === 'production'
                   ? null
                   : solution.id /* For Cypress test framework, need to include the solution ID so can search based on it */,
                 solution.name,
                 solution.description,
-              ]
-                .filter(Boolean)
-                .join(' ')
-                .toLowerCase();
-
-              return megaString.includes(this.state.filterQuery.toLowerCase());
-            })
+              ]),
+            )
             .map(sol => ({
               key: sol.id,
               title: sol.name,
@@ -116,18 +105,12 @@ class MySolutions extends React.Component<IProps> {
           <GalleryList
             title="My shared gists on GitHub"
             items={gistMetadata
-              .filter((meta: ISharedGistMetadata) => {
-                if (this.state.filterQuery === '') {
-                  return true;
-                }
-
-                const megaString = [meta.title, meta.description]
-                  .filter(Boolean)
-                  .join(' ')
-                  .toLowerCase();
-
-                return megaString.includes(this.state.filterQuery.toLowerCase());
-              })
+              .filter((meta: ISharedGistMetadata) =>
+                matchesSearch(this.state.filterQueryLowercase, [
+                  meta.title,
+                  meta.description,
+                ]),
+              )
               .map(gist => ({
                 key: gist.id,
                 title: gist.title,

--- a/packages/editor/src/pages/Editor/components/Backstage/MySolutions/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/MySolutions/index.tsx
@@ -85,7 +85,13 @@ class MySolutions extends React.Component<IProps> {
                 return true;
               }
 
-              const megaString = [solution.name, solution.description]
+              const megaString = [
+                process.env.NODE_ENV === 'production'
+                  ? null
+                  : solution.id /* For Cypress test framework, need to include the solution ID so can search based on it */,
+                solution.name,
+                solution.description,
+              ]
                 .filter(Boolean)
                 .join(' ')
                 .toLowerCase();

--- a/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
@@ -5,6 +5,7 @@ import Only from 'common/lib/components/Only';
 import Content from '../Content';
 import GalleryList from '../GalleryList';
 import { SearchBox } from 'office-ui-fabric-react/lib/components/SearchBox';
+import { matchesSearch } from 'common/lib/utilities/string';
 
 interface IProps {
   samplesByGroup: ISampleMetadataByGroup;

--- a/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
@@ -13,29 +13,30 @@ interface IProps {
 }
 
 interface IState {
-  filterQuery: string;
+  filterQueryLowercase: string;
 }
 
 class Samples extends Component<IProps, IState> {
-  state: IState = { filterQuery: '' };
+  state: IState = { filterQueryLowercase: '' };
 
-  setFilterQuery = (filterQuery: string) => this.setState({ filterQuery });
+  setFilterQuery = (filterQuery: string) =>
+    this.setState({ filterQueryLowercase: filterQuery.toLowerCase() });
 
   render() {
     const { samplesByGroup, openSample } = this.props;
 
     const filteredSamplesByGroup =
-      this.state.filterQuery !== ''
+      this.state.filterQueryLowercase !== ''
         ? Object.keys(samplesByGroup).reduce(
             (all, group) => ({
               ...all,
-              [group]: samplesByGroup[group].filter((sample: ISampleMetadata) => {
-                const megastring = [group, sample.name, sample.description]
-                  .filter(Boolean)
-                  .join(' ')
-                  .toLowerCase();
-                return megastring.includes(this.state.filterQuery.toLowerCase());
-              }),
+              [group]: samplesByGroup[group].filter((sample: ISampleMetadata) =>
+                matchesSearch(this.state.filterQueryLowercase, [
+                  group,
+                  sample.name,
+                  sample.description,
+                ]),
+              ),
             }),
             {},
           )

--- a/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
@@ -29,10 +29,11 @@ class Samples extends Component<IProps, IState> {
             (all, group) => ({
               ...all,
               [group]: samplesByGroup[group].filter((sample: ISampleMetadata) => {
-                const megastring = [sample.name, sample.description]
+                const megastring = [group, sample.name, sample.description]
                   .filter(Boolean)
-                  .join(' ');
-                return megastring.includes(this.state.filterQuery);
+                  .join(' ')
+                  .toLowerCase();
+                return megastring.includes(this.state.filterQuery.toLowerCase());
               }),
             }),
             {},


### PR DESCRIPTION
* For all searches, make them case-insensitive
* For samples, include the group name as well.  (I.e., "chart" should not hide anything from the "chart" group, even if a particular sample doesn't have "chart" in its description; the fact that it's under the "chart" group should be enough)
* For local snippets, only search based on name and description (just like all the others), NOT including file contents -- or else it's inconsistent, and brings up results that look like they have nothing to do with your query.