### PR TITLE
Makes GitHub fetch all Gists (fixes #332)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,8 @@ This is a particularly critical step for loading the Add-in inside of Office on 
 
 ## [Optional] Testing GitHub auth locally (on localhost)
 
-1. Go to <https://github.com/settings/developers>, and click "[Register new application](https://github.com/settings/applications/new)" if you haven't done it before for your own dev copy of ScriptLab.
-2. Give it a name like "ScriptLab Local Dev", with a Homepage and Auth callback URL of `https://localhost:3000`.
-3. Plumb this client ID and secret through (instructions TBD -- TODO).
+1. Run `yarn generate:github` and follow the instructions there.
+2. If your local website is already running, you will need to re-start it (re-`yarn start`)
 
 # Manual-testing scenarios
 
@@ -92,4 +91,6 @@ Please see "[TESTING.md](TESTING.md)".
 # Dev tips & tricks:
 
 - `packages/common`:
-  - When adding code to the `packages/common`, run `yarn workspace common build:package` in order to get Intellisense and the compiler to pick it up. In VS Code, you may need to `F12` into the file references before Intellisense is able to see the updated contents.
+  - When adding code to the `packages/common`, run `yarn workspace common build:package` in order to get Intellisense and the compiler to pick it up -- or just have `yarn start` already running and watching. In VS Code, you may need to `F12` into the file references before Intellisense is able to see the updated contents.
+- `packages/server`:
+  - To debug server code, navigate to `chrome://inspect/` and choose your server node process from there. Note that if your code changes and `nodemon` reloads the server, you will need to close the Inspector tool and re-open again from the link above.

--- a/package.json
+++ b/package.json
@@ -23,12 +23,16 @@
     "runner:test": "yarn workspace runner test",
     "server:test": "yarn workspace server test",
     "test": "npm-run-all --parallel common:test editor:test runner:test server:test",
-    "tscAll": "ts-node scripts/compile.all.ts"
+    "tscAll": "ts-node scripts/compile.all.ts",
+    "generate:github": "ts-node --project scripts/tsconfig.json scripts/generate.github.auth.ts"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.4",
+    "@types/inquirer": "^0.0.43",
     "@types/md5": "^2.1.33",
     "fs-extra": "^7.0.1",
+    "inquirer": "^6.2.1",
+    "nodemon": "^1.18.9",
     "npm-run-all": "^4.1.3",
     "prettier": "^1.15.2",
     "shelljs": "^0.8.2",

--- a/packages/common/src/environment.ts
+++ b/packages/common/src/environment.ts
@@ -24,7 +24,7 @@ const serverUrls: IReactEnvironments = {
 };
 
 const githubAppClientIds: IReactEnvironments = {
-  local: '210a167954d9ef04b501',
+  local: process.env.REACT_APP_GITHUB_CLIENT_ID,
   alpha: 'ad26df7ba62ef691669e',
   beta: 'edb61fe543b382628d68',
   staging: '',

--- a/packages/editor/src/pages/Editor/services/general.ts
+++ b/packages/editor/src/pages/Editor/services/general.ts
@@ -45,7 +45,7 @@ export const request = async ({
     if (response.ok) {
       return { response: await response.json(), headers: response.headers };
     } else {
-      return Promise.reject(response.statusText);
+      return Promise.reject(new Error(response.statusText));
     }
   } catch (error) {
     return { error };

--- a/packages/editor/src/pages/Editor/services/github.ts
+++ b/packages/editor/src/pages/Editor/services/github.ts
@@ -52,7 +52,6 @@ export const request = async ({
     nextUrl = getNextLinkIfAny(headers.get('Link'));
   }
 
-  debugger;
   return { response: aggregate };
 };
 

--- a/packages/editor/src/pages/Editor/services/github.ts
+++ b/packages/editor/src/pages/Editor/services/github.ts
@@ -22,27 +22,53 @@ auth.endpoints.add('GitHub', {
   tokenUrl: `${currentServerUrl}/auth`,
 });
 
-export const request = ({
+export const request = async ({
   method,
   path,
   token,
   jsonPayload,
-}: IRequest): Promise<IResponseOrError> =>
-  generalRequest({ url: `${baseApiUrl}/${path}`, method, token, jsonPayload });
+  isArrayResponse,
+}: IRequest & { isArrayResponse: boolean }): Promise<IResponseOrError> => {
+  let nextUrl = `${baseApiUrl}/${path}`;
+  let aggregate = [];
+
+  while (nextUrl) {
+    const { response, headers, error } = await generalRequest({
+      url: nextUrl,
+      method,
+      token,
+      jsonPayload,
+    });
+
+    if (error) {
+      return { error };
+    }
+
+    if (!isArrayResponse) {
+      return { response };
+    }
+
+    aggregate = [...aggregate, ...response];
+    nextUrl = getNextLinkIfAny(headers.get('Link'));
+  }
+
+  debugger;
+  return { response: aggregate };
+};
 
 export const login = async (): Promise<{
   token?: string;
   profilePicUrl?: string;
   username?: string;
 }> => {
-  let itoken: IToken;
+  let iToken: IToken;
   try {
-    itoken = await auth.authenticate('GitHub');
+    iToken = await auth.authenticate('GitHub');
   } catch (err) {
     console.error(err);
     throw err;
   }
-  const token = itoken.access_token;
+  const token = iToken.access_token;
 
   return {
     token,
@@ -57,6 +83,7 @@ export const getProfilePicUrlAndUsername = (
     method: 'GET',
     path: 'user',
     token,
+    isArrayResponse: false,
   }).then(({ response, error }) => {
     if (error) {
       console.error(error);
@@ -69,4 +96,18 @@ export const getProfilePicUrlAndUsername = (
     }
   });
 
-export const logout = (token: string) => auth.tokens.clear();
+export const logout = () => auth.tokens.clear();
+
+function getNextLinkIfAny(linkText: string): string | null {
+  const regex = /\<(https:[^\>]*)\>; rel="next"/;
+  // Matches the rel="next" section of a longer entry, like:
+  // <https://api.github.com/gists?page=5>; rel="next", <https://api.github.com/gists?page=1>; rel="first"
+
+  const pair = regex.exec(linkText);
+
+  if (pair) {
+    return pair[1]; // Group 1, the URL portion
+  }
+
+  return null;
+}

--- a/packages/editor/src/pages/Editor/store/configureStore.ts
+++ b/packages/editor/src/pages/Editor/store/configureStore.ts
@@ -13,13 +13,15 @@ const addLoggingToDispatch = store => {
     return rawDispatch;
   }
   return action => {
-    console.group(action.type);
-    console.log('%c prev state', 'color: gray', store.getState());
-    console.log('%c action', 'color: blue', action);
-    const returnValue = rawDispatch(action);
-    console.log('%c next state', 'color: green', store.getState());
-    console.groupEnd();
-    return returnValue;
+    if (action && action.type) {
+      console.group(action.type);
+      console.log('%c prev state', 'color: gray', store.getState());
+      console.log('%c action', 'color: blue', action);
+      const returnValue = rawDispatch(action);
+      console.log('%c next state', 'color: green', store.getState());
+      console.groupEnd();
+      return returnValue;
+    }
   };
 };
 

--- a/packages/editor/src/pages/Editor/store/gists/actions.ts
+++ b/packages/editor/src/pages/Editor/store/gists/actions.ts
@@ -28,7 +28,7 @@ export const fetchMetadata = createAsyncAction(
   'FETCH_GIST_METADATA_REQUEST',
   'FETCH_GIST_METADATA_SUCCESS',
   'FETCH_GIST_METADATA_FAILURE',
-)<void, ISharedGistMetadata[], Error>();
+)<void, ISharedGistMetadata[], { shouldLogUserOut: boolean }>();
 
 export const get = createAsyncAction(
   'GET_GIST_REQUEST',

--- a/packages/editor/src/pages/Editor/store/gists/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/gists/sagas.ts
@@ -3,7 +3,7 @@ import { getType, ActionType } from 'typesafe-actions';
 import YAML from 'js-yaml';
 
 import * as github from '../../services/github';
-import { fetchYaml } from '../../services/general';
+import { fetchYaml, IResponseOrError } from '../../services/general';
 import { gists, editor, solutions } from '../actions';
 import selectors from '../selectors';
 
@@ -11,13 +11,12 @@ import { convertSnippetToSolution, convertSolutionToSnippet } from '../../../../
 import { ConflictResolutionOptions } from '../../../../interfaces/enums';
 
 import { createSolutionSaga } from '../solutions/sagas';
-import { push } from 'connected-react-router';
-import { PATHS } from '../../../../constants';
 import { checkForUnsupportedAPIsIfRelevant } from './utilities';
 
 export default function* gistsWatcher() {
   yield takeEvery(getType(gists.fetchMetadata.request), fetchAllGistMetadataSaga);
   yield takeEvery(getType(gists.fetchMetadata.success), onFetchGistMetadataSuccessSaga);
+  yield takeEvery(getType(gists.fetchMetadata.failure), onFetchGistMetadataFailureSaga);
 
   yield takeEvery(getType(gists.get.request), getGistSaga);
   yield takeEvery(getType(gists.get.success), handleGetGistSuccessSaga);
@@ -40,7 +39,7 @@ export function* fetchAllGistMetadataSaga() {
 
   const currentHost = yield select(selectors.host.get);
 
-  const { response, error } = yield call(github.request, {
+  const { response, error }: IResponseOrError = yield call(github.request, {
     method: 'GET',
     path: 'gists?per_page=100',
     token,
@@ -83,7 +82,9 @@ export function* fetchAllGistMetadataSaga() {
 
     yield put(gists.fetchMetadata.success(gistsMetadata));
   } else {
-    yield put(gists.fetchMetadata.failure(error));
+    yield put(
+      gists.fetchMetadata.failure({ shouldLogUserOut: error.message === 'Unauthorized' }),
+    );
   }
 }
 
@@ -102,6 +103,14 @@ function* onFetchGistMetadataSuccessSaga(
 
   for (const solution of solutionsToClean) {
     yield put(solutions.edit({ id: solution.id, solution: { source: undefined } }));
+  }
+}
+
+function* onFetchGistMetadataFailureSaga(
+  action: ActionType<typeof gists.fetchMetadata.failure>,
+) {
+  if (action.payload.shouldLogUserOut) {
+    github.logout();
   }
 }
 

--- a/packages/editor/src/pages/Editor/store/gists/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/gists/sagas.ts
@@ -42,8 +42,9 @@ export function* fetchAllGistMetadataSaga() {
 
   const { response, error } = yield call(github.request, {
     method: 'GET',
-    path: 'gists',
+    path: 'gists?per_page=100',
     token,
+    isArrayResponse: true,
   });
 
   if (response) {
@@ -166,6 +167,7 @@ function* createGistSaga(action: ActionType<typeof gists.create.request>) {
   const { response, error } = yield call(github.request, {
     method: 'POST',
     path: 'gists',
+    isArrayResponse: false,
     token,
     jsonPayload: JSON.stringify({
       public: action.payload.isPublic,
@@ -212,6 +214,7 @@ function* updateGistSaga(action: ActionType<typeof gists.update.request>) {
     const { response, error } = yield call(github.request, {
       method: 'PATCH',
       path: `gists/${gistId}`,
+      isArrayResponse: false,
       token,
       jsonPayload: JSON.stringify({
         description: `${solution.description}`,

--- a/packages/editor/src/pages/Editor/store/github/reducer.ts
+++ b/packages/editor/src/pages/Editor/store/github/reducer.ts
@@ -1,14 +1,20 @@
 import { combineReducers } from 'redux';
-import { github, IGithubAction } from '../actions';
+import { github, IGithubAction, gists, IGistsAction } from '../actions';
 import { getType } from 'typesafe-actions';
 
 type ITokenState = string | null;
-const token = (state: ITokenState = null, action: IGithubAction): ITokenState => {
+const token = (
+  state: ITokenState = null,
+  action: IGithubAction | IGistsAction,
+): ITokenState => {
   switch (action.type) {
     case getType(github.login.success):
       return action.payload.token;
     case getType(github.logout.success):
+    case getType(github.login.failure):
       return null;
+    case getType(gists.fetchMetadata.failure):
+      return action.payload.shouldLogUserOut ? null : state;
     default:
       return state;
   }
@@ -17,13 +23,16 @@ const token = (state: ITokenState = null, action: IGithubAction): ITokenState =>
 type IProfilePicUrlState = string | null;
 const profilePicUrl = (
   state: IProfilePicUrlState = null,
-  action: IGithubAction,
+  action: IGithubAction | IGistsAction,
 ): IProfilePicUrlState => {
   switch (action.type) {
     case getType(github.login.success):
       return action.payload.profilePicUrl;
     case getType(github.logout.success):
+    case getType(github.login.failure):
       return null;
+    case getType(gists.fetchMetadata.failure):
+      return action.payload.shouldLogUserOut ? null : state;
     default:
       return state;
   }
@@ -32,13 +41,16 @@ const profilePicUrl = (
 type IUsernameState = string | null;
 const username = (
   state: IUsernameState = null,
-  action: IGithubAction,
+  action: IGithubAction | IGistsAction,
 ): IUsernameState => {
   switch (action.type) {
     case getType(github.login.success):
       return action.payload.username;
     case getType(github.logout.success):
+    case getType(github.login.failure):
       return null;
+    case getType(gists.fetchMetadata.failure):
+      return action.payload.shouldLogUserOut ? null : state;
     default:
       return state;
   }

--- a/packages/editor/src/pages/Editor/store/github/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/github/sagas.ts
@@ -6,6 +6,12 @@ import { login, logout } from '../../services/github';
 import { fetchAllGistMetadataSaga } from '../gists/sagas';
 import selectors from '../selectors';
 
+export default function* githubWatcher() {
+  yield takeEvery(getType(github.login.request), gitHubLoginSaga);
+  yield takeEvery(getType(github.login.success), fetchAllGistMetadataSaga);
+  yield takeEvery(getType(github.logout.request), gitHubLogoutSaga);
+}
+
 function* gitHubLoginSaga(action: ActionType<typeof github.login.request>) {
   try {
     const profile = yield call(login);
@@ -20,10 +26,4 @@ function* gitHubLogoutSaga(action: ActionType<typeof github.logout.request>) {
   const token = yield select(selectors.github.getToken);
   yield call(logout, token);
   yield put(github.logout.success());
-}
-
-export default function* githubWatcher() {
-  yield takeEvery(getType(github.login.request), gitHubLoginSaga);
-  yield takeEvery(getType(github.login.success), fetchAllGistMetadataSaga);
-  yield takeEvery(getType(github.logout.request), gitHubLogoutSaga);
 }

--- a/packages/editor/src/pages/Editor/store/header/selectors.ts
+++ b/packages/editor/src/pages/Editor/store/header/selectors.ts
@@ -321,7 +321,7 @@ export const getFarItems = createSelector(
                     {
                       key: 'logout',
                       text: 'Logout',
-                      actionCreator: actions.github.logout,
+                      actionCreator: actions.github.logout.request,
                     },
                   ],
                 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,7 +2,7 @@
   "name": "server",
   "version": "1.0.0",
   "scripts": {
-    "start": "node src/index.ts",
+    "start": "nodemon --inspect src/index.ts",
     "build": "webpack-cli",
     "lint": "tslint \"src/**/*.ts?(x)\"",
     "test": "echo 'no tests'"

--- a/scripts/generate.github.auth.ts
+++ b/scripts/generate.github.auth.ts
@@ -35,7 +35,7 @@ import * as SimplePrompt from './helpers/simple.prompt';
   );
 
   fs.writeFileSync(
-    path.resolve(root, 'packages/server/.env.development.local'),
+    path.resolve(root, 'packages/server/.env'),
     stripSpaces(`
       GITHUB_CLIENT_ID=${clientId}
       GITHUB_CLIENT_SECRET=${clientSecret}

--- a/scripts/generate.github.auth.ts
+++ b/scripts/generate.github.auth.ts
@@ -1,0 +1,52 @@
+import path from 'path';
+import fs from 'fs-extra';
+
+import { stripSpaces } from 'common/lib/utilities/string';
+import * as SimplePrompt from './helpers/simple.prompt';
+
+(async () => {
+  console.log(
+    stripSpaces(`
+        This script will set you up with doing local GitHub auth.
+        
+        If you haven't already, go to https://github.com/settings/developers
+        and click "Register new application".
+        Give it a name like "ScriptLab Local Dev",
+        with a Homepage and Auth callback URL of https://localhost:3000
+        
+        Once you've done that, please enter the following details from your app registration:
+    `),
+  );
+
+  let clientId = await SimplePrompt.promptCustomText('Client ID:', { required: true });
+  let clientSecret = await SimplePrompt.promptCustomText('Client Secret:', {
+    required: true,
+  });
+
+  const root = path.resolve(__dirname, '../');
+
+  fs.writeFileSync(
+    path.resolve(root, 'packages/server/.env'),
+    stripSpaces(`
+      GITHUB_CLIENT_ID=${clientId}
+      GITHUB_CLIENT_SECRET=${clientSecret}
+      GITHUB_REDIRECT_URL=https://localhost:3000/
+    `),
+  );
+
+  fs.writeFileSync(
+    path.resolve(root, 'packages/server/.env.development.local'),
+    stripSpaces(`
+      GITHUB_CLIENT_ID=${clientId}
+      GITHUB_CLIENT_SECRET=${clientSecret}
+      GITHUB_REDIRECT_URL=https://localhost:3000/
+    `),
+  );
+
+  fs.writeFileSync(
+    path.resolve(root, 'packages/editor/.env.development.local'),
+    stripSpaces(`
+      REACT_APP_GITHUB_CLIENT_ID=${clientId}
+    `),
+  );
+})();

--- a/scripts/helpers/simple.prompt.ts
+++ b/scripts/helpers/simple.prompt.ts
@@ -1,0 +1,111 @@
+import * as inquirer from 'inquirer';
+import { cloneDeep, isString, isUndefined } from 'lodash';
+
+const NO_CHOICE_SELECTED = '---';
+
+export async function promptFromList<T>(options: {
+  message: string;
+  choices: Array<string | { value: string; name: string; keepIf?: boolean }>;
+  mappings: { [key: string]: T };
+  onQuit?: () => any;
+}): Promise<T>;
+export async function promptFromList<T extends string>(options: {
+  message: string;
+  choices: Array<string | { value: T; name: string; keepIf?: boolean }>;
+  onQuit?: () => any;
+}): Promise<T>;
+export async function promptFromList(options: {
+  message: string;
+  choices: Array<string | { value: string; name: string; keepIf?: boolean }>;
+  onQuit?: () => any;
+  mappings?: { [key: string]: any };
+}): Promise<any> {
+  let appendedChoices: Array<typeof options.choices[0] | typeof NO_CHOICE_SELECTED> = [
+    NO_CHOICE_SELECTED,
+  ].concat(cloneDeep(options.choices) as any);
+
+  const realChoices: { value: string; name: string }[] = appendedChoices
+    .map(item => {
+      if (isString(item)) {
+        return { value: item, name: item };
+      } else {
+        if (isUndefined(item.keepIf)) {
+          return item;
+        } else {
+          return item.keepIf ? item : null;
+        }
+      }
+    })
+    .filter(item => item != null)
+    .map((item, index) => {
+      const { value, name } = item!;
+      return { value, name, key: index + 1 };
+    });
+
+  let answer = (await inquirer.prompt({
+    type: 'list',
+    name: 'question',
+    message: options.message,
+    choices: realChoices,
+  }))['question'] as string;
+
+  if (answer === NO_CHOICE_SELECTED) {
+    console.log('You needed to choose one of the options. Please try again.');
+    return promptFromList(options as any);
+  } else if (answer.toLowerCase() === 'quit') {
+    if (options.onQuit) {
+      await options.onQuit();
+    }
+    quit();
+  } else {
+    if (options.mappings) {
+      const remappedAnswer = options.mappings[answer.toLowerCase()];
+      if (isUndefined(remappedAnswer)) {
+        throw new Error(
+          `No re-mapping specified for answer "${answer}" to question "${
+            options.message
+          }".`,
+        );
+      }
+      return remappedAnswer;
+    }
+
+    return answer as any;
+  }
+}
+
+export async function promptCustomText(
+  message: string,
+  options: { required: boolean },
+): Promise<string> {
+  let keepGoing = true;
+
+  while (keepGoing) {
+    let answer = ((await inquirer.prompt({
+      name: 'question',
+      message: message,
+    }))['question'] as string).trim();
+
+    if (answer.toLowerCase() === 'quit') {
+      keepGoing = false;
+      quit();
+    }
+
+    if (options.required && answer.length == 0) {
+      // Just keep going...
+    } else {
+      return answer;
+    }
+  }
+}
+
+export async function promptToPressEnterToContinueOrQuitToExit(): Promise<void> {
+  await promptCustomText(`Press <enter> to continue, or type "quit" to exit: `, {
+    required: false,
+  });
+}
+
+function quit() {
+  console.log('You have chosen to quit.');
+  process.exit(0);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,6 +1499,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/inquirer@^0.0.43":
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-0.0.43.tgz#1eb0bbb4648e6cc568bd396c1e989f620ad01273"
+  integrity sha512-xgyfKZVMFqE8aIKy1xfFVsX2MxyXUNgjgmbF6dRbR3sL+ZM5K4ka/9L4mmTwX8eTeVYtduyXu0gUVwVJa1HbNw==
+  dependencies:
+    "@types/rx" "*"
+    "@types/through" "*"
+
 "@types/jest@^23.3.2", "@types/jest@^23.3.9":
   version "23.3.10"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
@@ -1638,6 +1646,107 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/rx-core-binding@*":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz#d969d32f15a62b89e2862c17b3ee78fe329818d3"
+  integrity sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==
+  dependencies:
+    "@types/rx-core" "*"
+
+"@types/rx-core@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/rx-core/-/rx-core-4.0.3.tgz#0b3354b1238cedbe2b74f6326f139dbc7a591d60"
+  integrity sha1-CzNUsSOM7b4rdPYybxOdvHpZHWA=
+
+"@types/rx-lite-aggregates@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz#6efb2b7f3d5f07183a1cb2bd4b1371d7073384c2"
+  integrity sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-async@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz#27fbf0caeff029f41e2d2aae638b05e91ceb600c"
+  integrity sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-backpressure@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz#05abb19bdf87cc740196c355e5d0b37bb50b5d56"
+  integrity sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-coincidence@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz#80bd69acc4054a15cdc1638e2dc8843498cd85c0"
+  integrity sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-experimental@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz#c532f5cbdf3f2c15da16ded8930d1b2984023cbd"
+  integrity sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-joinpatterns@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz#f70fe370518a8432f29158cc92ffb56b4e4afc3e"
+  integrity sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-testing@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz#21b19d11f4dfd6ffef5a9d1648e9c8879bfe21e9"
+  integrity sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=
+  dependencies:
+    "@types/rx-lite-virtualtime" "*"
+
+"@types/rx-lite-time@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz#0eda65474570237598f3448b845d2696f2dbb1c4"
+  integrity sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite-virtualtime@*":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz#4b30cacd0fe2e53af29f04f7438584c7d3959537"
+  integrity sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==
+  dependencies:
+    "@types/rx-lite" "*"
+
+"@types/rx-lite@*":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/rx-lite/-/rx-lite-4.0.6.tgz#3c02921c4244074234f26b772241bcc20c18c253"
+  integrity sha512-oYiDrFIcor9zDm0VDUca1UbROiMYBxMLMaM6qzz4ADAfOmA9r1dYEcAFH+2fsPI5BCCjPvV9pWC3X3flbrvs7w==
+  dependencies:
+    "@types/rx-core" "*"
+    "@types/rx-core-binding" "*"
+
+"@types/rx@*":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@types/rx/-/rx-4.1.1.tgz#598fc94a56baed975f194574e0f572fd8e627a48"
+  integrity sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=
+  dependencies:
+    "@types/rx-core" "*"
+    "@types/rx-core-binding" "*"
+    "@types/rx-lite" "*"
+    "@types/rx-lite-aggregates" "*"
+    "@types/rx-lite-async" "*"
+    "@types/rx-lite-backpressure" "*"
+    "@types/rx-lite-coincidence" "*"
+    "@types/rx-lite-experimental" "*"
+    "@types/rx-lite-joinpatterns" "*"
+    "@types/rx-lite-testing" "*"
+    "@types/rx-lite-time" "*"
+    "@types/rx-lite-virtualtime" "*"
+
 "@types/sanitize-html@^1.18.2":
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-1.18.2.tgz#14e9971064d0f29aa4feaa8421122ced9e8346d9"
@@ -1734,6 +1843,13 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
   integrity sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==
+
+"@types/through@*":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.29.tgz#72943aac922e179339c651fa34a4428a4d722f93"
+  integrity sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==
+  dependencies:
+    "@types/node" "*"
 
 "@types/uuid@^3.4.4":
   version "3.4.4"
@@ -2260,6 +2376,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -4411,7 +4532,7 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-cypress@3.1.4:
+cypress@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.1.4.tgz#2af04da05e09f9d3871d05713b364472744c4216"
   integrity sha512-8VJYtCAFqHXMnRDo4vdomR2CqfmhtReoplmbkXVspeKhKxU8WsZl0Nh5yeil8txxhq+YQwDrInItUqIm35Vw+g==
@@ -6843,6 +6964,25 @@ inquirer@6.2.0, inquirer@^6.1.0, inquirer@^6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+inquirer@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
+  integrity sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.0.0"
+    through "^2.3.6"
+
 internal-ip@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-3.0.1.tgz#df5c99876e1d2eb2ea2d74f520e3f669a00ece27"
@@ -8940,6 +9080,22 @@ nodemon@^1.18.3:
     undefsafe "^2.0.2"
     update-notifier "^2.3.0"
 
+nodemon@^1.18.9:
+  version "1.18.9"
+  resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-1.18.9.tgz#90b467efd3b3c81b9453380aeb2a2cba535d0ead"
+  integrity sha512-oj/eEVTEI47pzYAjGkpcNw0xYwTl4XSTUQv2NPQI6PpN3b75PhpuYk3Vb3U80xHCyM2Jm+1j68ULHXl4OR3Afw==
+  dependencies:
+    chokidar "^2.0.4"
+    debug "^3.1.0"
+    ignore-by-default "^1.0.1"
+    minimatch "^3.0.4"
+    pstree.remy "^1.1.6"
+    semver "^5.5.0"
+    supports-color "^5.2.0"
+    touch "^3.1.0"
+    undefsafe "^2.0.2"
+    update-notifier "^2.5.0"
+
 nomnom@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
@@ -10409,6 +10565,11 @@ pstree.remy@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.2.tgz#4448bbeb4b2af1fed242afc8dc7416a6f504951a"
   integrity sha512-vL6NLxNHzkNTjGJUpMm5PLC+94/0tTlC1vkP9bdU0pOHih+EujMjgMTwfZopZvHWRFbqJ5Y73OMoau50PewDDA==
+
+pstree.remy@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.6.tgz#73a55aad9e2d95814927131fbf4dc1b62d259f47"
+  integrity sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w==
 
 public-encrypt@^4.0.0:
   version "4.0.3"
@@ -12211,6 +12372,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
+  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
+  dependencies:
+    ansi-regex "^4.0.0"
+
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -12918,7 +13086,7 @@ upath@^1.0.5:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
   integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
 
-update-notifier@^2.3.0:
+update-notifier@^2.3.0, update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==


### PR DESCRIPTION
Adds support for array-style responses from GitHub (e.g., for paging through multiple Gists).

Also adds a convenient script for generating the files needed for local github auth.

Also makes server be run with nodemon (which will restart it on file changes) and be debuggable (passing `--inspect` flag, which doesn't hurt anything if you don't connect the debugger, but leaves that possibility open)