### PR TITLE
Scope pop-out editor to only Outlook or Office Online

### DIFF
--- a/packages/editor/src/pages/Editor/store/header/selectors.ts
+++ b/packages/editor/src/pages/Editor/store/header/selectors.ts
@@ -27,7 +27,7 @@ import {
   solutions,
   settings,
 } from '../actions';
-import { Utilities, HostType } from '@microsoft/office-js-helpers';
+import { Utilities, HostType, PlatformType } from '@microsoft/office-js-helpers';
 
 const actions = { dialog, editor, gists, github, messageBar, misc, solutions, settings };
 
@@ -343,9 +343,14 @@ export const getFarItems = createSelector(
 );
 
 function shouldShowPopoutControls() {
-  // On desktop, show the popout control in Outlook -- but DON'T for Word/Excel/PPT,
-  //    since on those hosts, you can just resize the taskpane (or even drag it out!).
-  //    And relative to a popped-out taskpane, this has a few advantages:
+  // IMPORTANT: IF YOU MAKE ANY CHANGES HERE, UPDATE THE RUNNER'S
+  // "shouldShowPopoutControls" logic to be similar!
+
+  // Show the popout control in Outlook and on Office Online, but not anywhere else.
+
+  // On desktop, decided not to show it because on that platform,
+  // you can just resize the taskpane (or even drag it out!).
+  // And relative to a popped-out taskpane, this has a few advantages:
   // 1. With a dialog, closing the underlying "run" pane (to which the taskpane redirects)
   //       closes the editor, which is awkward.
   // 2. With a dialog, re-clicking on "Code" in the ribbon (e.g. accidentally)
@@ -353,5 +358,19 @@ function shouldShowPopoutControls() {
   // 3. With a dialog, the "Run" actually happens inside a pane called "Code", which is awkward
   // 4. Clicking on "Run" in the ribbon produces two runners, which is confusing.
 
-  return getIsInAddin() && (Utilities.host === HostType.OUTLOOK || !getIsInDesktop());
+  // On the Mac (at least for Excel/Word/PPT), it doesn't seem to work
+  // (due to some interaction between Office.js and our routing behavior),
+  // and it's not worth it for now to try to investigate.
+  // See https://github.com/OfficeDev/script-lab/issues/578
+  // For now, only enabling it where we tested it (and where it's most useful),
+  //     which is Office Online
+
+  if (!getIsInAddin()) {
+    return false;
+  }
+
+  return (
+    Utilities.host === HostType.OUTLOOK ||
+    Utilities.platform === PlatformType.OFFICE_ONLINE
+  );
 }

--- a/packages/runner/src/pages/Runner/components/App/Header.tsx
+++ b/packages/runner/src/pages/Runner/components/App/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import CommonHeader from 'common/lib/components/Header';
+import { Utilities, HostType, PlatformType } from '@microsoft/office-js-helpers';
 
 export interface IProps {
   solution?: ISolution | null;
@@ -47,13 +48,15 @@ const Header = ({ solution, goBack, refresh, hardRefresh, openCode }: IProps) =>
             text: 'Hard Refresh',
             onClick: hardRefresh,
           },
-          {
-            key: 'pop-out',
-            iconProps: { iconName: 'OpenInNewWindow' },
-            text: 'Open Code Editor',
-            onClick: openCode,
-          },
-        ],
+          shouldShowPopoutControls()
+            ? {
+                key: 'pop-out',
+                iconProps: { iconName: 'OpenInNewWindow' },
+                text: 'Open Code Editor',
+                onClick: openCode,
+              }
+            : null,
+        ].filter(item => item !== null),
       },
     },
   ];
@@ -62,3 +65,23 @@ const Header = ({ solution, goBack, refresh, hardRefresh, openCode }: IProps) =>
 };
 
 export default Header;
+
+///////////////////////////////////////
+
+function shouldShowPopoutControls() {
+  // IMPORTANT: IF YOU MAKE ANY CHANGES HERE, UPDATE THE EDITOR'S
+  // "shouldShowPopoutControls" logic to be similar!
+
+  // For an explanation of why we're only enabling the particular platforms/hosts
+  //     see the Editor's version of this function.
+
+  // Also note that on the Mac, popping out the editor doesn't work
+  // if you've navigated to the runner from the Editor domain -- likely
+  // because some Office.js context gets lost (?).  In either case,
+  // we're ok with doing it only for Office Online for now.
+
+  return (
+    Utilities.host === HostType.OUTLOOK ||
+    Utilities.platform === PlatformType.OFFICE_ONLINE
+  );
+}


### PR DESCRIPTION
Due to continued issues on the Mac -- and because this was never a "funded" feature -- scoping the pop-out button to only work on Outlook and on Office Online.  So: no pop-out button on Mac or Desktop for Excel/Word/PPT.

@annich-MS , note that while the Mac scoping-out decision might be OK for us with Excel/Word/PPT -- is this a deal-breaker for Outlook?  If so, you'll need to investigate more...