### PR TITLE
Fixes issue with hard-refresh not working.

### DIFF
--- a/packages/editor/src/pages/Editor/store/misc/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/misc/sagas.ts
@@ -99,8 +99,13 @@ function* onConfirmSwitchEnvironmentSaga(
 }
 
 function* onPopOutEditorSaga() {
+  showSplashScreen('Navigating to the runner. Please wait...');
+
   openPopoutCodeEditor({
     onSuccess: () => (window.location.href = currentRunnerUrl),
+
+    // Note: on failure will show a dialog which will displace the splash screen.
+    // And which, when dismissed, will reveal the editor again.  So nothing special to do on failure.
   });
 }
 

--- a/packages/runner/src/pages/Runner/components/App/index.tsx
+++ b/packages/runner/src/pages/Runner/components/App/index.tsx
@@ -228,23 +228,24 @@ export class App extends React.Component<{}, IState> {
   // and thus will get invoked with an object-based click-event parameter
   // rather than a string, messing up the reload.
   private reloadPageWithDifferentOfficeJsUrl(newOfficeJsUrl: string | null) {
-    const newQueryParams: { [key: string]: any } = queryString.parse(
+    const currentQueryParams: { [key: string]: any } = queryString.parse(
       window.location.search,
     );
 
-    if (newOfficeJsUrl) {
-      newQueryParams[OFFICE_JS_URL_QUERY_PARAMETER_KEY] = newOfficeJsUrl;
-    }
+    const isDifferentOfficeJs =
+      newOfficeJsUrl &&
+      newOfficeJsUrl !== currentQueryParams[OFFICE_JS_URL_QUERY_PARAMETER_KEY];
 
-    const newParams = '?' + queryString.stringify(newQueryParams);
-    if (
-      newParams.length === 1 /* just the question mark */ ||
-      newParams === window.location.search
-    ) {
-      window.location.reload();
-    } else {
+    if (isDifferentOfficeJs) {
+      const newParams = {
+        ...currentQueryParams,
+        [OFFICE_JS_URL_QUERY_PARAMETER_KEY]: newOfficeJsUrl,
+      };
+
       // Set the search, which will force a reload
-      window.location.search = newParams;
+      window.location.search = queryString.stringify(newParams);
+    } else {
+      window.location.reload();
     }
   }
 

--- a/packages/runner/src/pages/Runner/components/App/index.tsx
+++ b/packages/runner/src/pages/Runner/components/App/index.tsx
@@ -236,8 +236,16 @@ export class App extends React.Component<{}, IState> {
       newQueryParams[OFFICE_JS_URL_QUERY_PARAMETER_KEY] = newOfficeJsUrl;
     }
 
-    const newParams = queryString.stringify(newQueryParams);
-    window.location.search = newParams;
+    const newParams = '?' + queryString.stringify(newQueryParams);
+    if (
+      newParams.length === 1 /* just the question mark */ ||
+      newParams === window.location.search
+    ) {
+      window.location.reload();
+    } else {
+      // Set the search, which will force a reload
+      window.location.search = newParams;
+    }
   }
 
   private respondToOfficeJsMismatchIfAny(solution: ISolution) {


### PR DESCRIPTION
The problem was that if window.location.search didn't need to change, it was no-op-ing and not reloading the page.
This fix should help detect whether it will be a no-op, and, if so, do a forced "window.location.reload()"

Fixes #603 