### PR TITLE
update VSCode recommended tslint extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
   "recommendations": [
     // Extension identifier format: ${publisher}.${name}
     "esbenp.prettier-vscode",
-    "eg2.tslint",
+    "ms-vscode.vscode-typescript-tslint-plugin",
     "robertohuertasm.vscode-icons",
     "coenraads.bracket-pair-colorizer",
     "wayou.vscode-todo-highlight",


### PR DESCRIPTION
eg2.tslint has been deprecated in favor of vscode-typescript-tslint-plugin.