### PR TITLE
Fix auth on Edge

### DIFF
--- a/packages/editor/src/pages/Auth/index.tsx
+++ b/packages/editor/src/pages/Auth/index.tsx
@@ -247,10 +247,13 @@ class AuthPage extends React.Component<IProps, IState> {
 
       // Note: can use "crypto" directly here because by the time get to this code,
       // don't need to worry about IE11.
+      // However, still need the "hash" parameter since Edge requires it
+      //   (see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12782429/)
       const encryptedArrayBuffer = await crypto.subtle.encrypt(
         {
           name: 'RSA-OAEP',
-        },
+          hash: { name: 'SHA-256' } /* See note above for why it's needed */,
+        } as any,
         publicKey,
         unicodeStringToBuffer(token),
       );


### PR DESCRIPTION
With the move to use "crypto.subtle" rather than "node-rsa", it looks like Edge got broken because of the undocumented "hash" parameter that nonetheless needs to be passed in on Edge.  This fixes it.