### PR TITLE
Don't show run/register buttons when in pop-out editor

### DIFF
--- a/packages/common/src/utilities/popout.control.ts
+++ b/packages/common/src/utilities/popout.control.ts
@@ -7,10 +7,8 @@ import { ScriptLabError } from './error';
 const IS_DIALOG_QUERY_PARAMETER = 'isDialog';
 
 export function shouldShowPopoutControl(context: 'editor' | 'runner'): boolean {
-  const params: { [key: string]: any } = queryString.parse(window.location.search);
-
   // If already is popped out in a dialog, don't show the popout control
-  if (params[IS_DIALOG_QUERY_PARAMETER]) {
+  if (isPoppedOut()) {
     return false;
   }
 
@@ -65,6 +63,11 @@ export function openPopoutCodeEditor(
       }
     },
   );
+}
+
+export function isPoppedOut(): boolean {
+  const params: { [key: string]: any } = queryString.parse(window.location.search);
+  return params[IS_DIALOG_QUERY_PARAMETER] ? true : false;
 }
 
 function getPopoutEditorUrl() {

--- a/packages/editor/src/pages/Editor/store/host/selectors.ts
+++ b/packages/editor/src/pages/Editor/store/host/selectors.ts
@@ -1,6 +1,7 @@
 import { IState } from '../reducer';
 import { createSelector } from 'reselect';
 import { Utilities, HostType, PlatformType } from '@microsoft/office-js-helpers';
+import { isPoppedOut } from 'common/lib/utilities/popout.control';
 
 const getHostsMatch = (state: IState): boolean => state.host === Utilities.host;
 
@@ -9,5 +10,5 @@ export const getIsWeb = (_?: IState): boolean => Utilities.host === HostType.WEB
 export const getIsInDesktop = (_?: IState) => Utilities.platform === PlatformType.PC;
 export const getIsRunnableOnThisHost = createSelector(
   [get, getHostsMatch],
-  (host, hostsMatch) => host !== HostType.OUTLOOK && hostsMatch,
+  (host, hostsMatch) => host !== HostType.OUTLOOK && hostsMatch && !isPoppedOut(),
 );


### PR DESCRIPTION
When in popped-out mode in the dialog API, the dialog can't call into any host APIs (other than messaging parent).  So neither "run" nor "register [custom functions]" will work.

Thus, shouldn't be showing these buttons.