### PR TITLE
Upgrade to Monaco 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "server:test": "yarn workspace server test",
     "test": "npm-run-all --parallel common:test editor:test runner:test server:test",
     "tscAll": "ts-node scripts/compile.all.ts",
-    "generate:github": "ts-node --project scripts/tsconfig.json scripts/generate.github.auth.ts"
+    "generate:github": "ts-node --project scripts/tsconfig.json scripts/generate.github.auth.ts",
+    "terminate:windows": "taskkill /f /im node.exe"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.4",

--- a/packages/common/src/package-versions.ts
+++ b/packages/common/src/package-versions.ts
@@ -1,8 +1,5 @@
 export const PACKAGE_VERSIONS = {
-  'monaco-editor': '0.14.3',
-  'monaco-editor-old':
-    '0.10.1' /* for Mac mouse-focus issue, see more at
-    https://github.com/OfficeDev/script-lab/issues/506 */,
+  'monaco-editor': '0.16.0',
   '@microsoft/office-js': '1.1.11-adhoc.28',
 };
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies_comments": {
-    "query-string": "Restricing query-string to version 5.1.1 because later versions (6+) started targeting ES6 rather than ES5, making it not work for the precompile scripts. See more at https://stackoverflow.com/a/49985749/678505",
-    "monaco-editor": "On Mac add-ins, versions of Monaco 0.11.0 - 0.15.6 all DON'T WORK (can't click on anything other than last line of text!).  So for now sticking with the last working version, 0.10.1"
+    "query-string": "Restricing query-string to version 5.1.1 because later versions (6+) started targeting ES6 rather than ES5, making it not work for the precompile scripts. See more at https://stackoverflow.com/a/49985749/678505"
   },
   "dependencies": {
     "@microsoft/office-js": "1.1.11-adhoc.28",
@@ -15,8 +14,7 @@
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
-    "monaco-editor": "npm:monaco-editor@0.14.3",
-    "monaco-editor-old": "npm:monaco-editor@0.10.1",
+    "monaco-editor": "^0.16.0",
     "normalizr": "^3.2.4",
     "office-ui-fabric-react": "^6.114.0",
     "query-string": "5.1.1",

--- a/packages/editor/public/monaco-test.html
+++ b/packages/editor/public/monaco-test.html
@@ -26,9 +26,7 @@
     <br />
     <div>
       Note: for a local version, can use <br />
-      "https://localhost:3000/external/monaco-editor-0-10-1/vs" <br />
-      or <br />
-      "https://localhost:3000/external/monaco-editor-0-14-3/vs" <br />
+      "https://localhost:3000/external/monaco-editor-0-16-0/vs" <br />
     </div>
 
     <script src="./monaco-test.js"></script>

--- a/packages/editor/scripts/postinstall.ts
+++ b/packages/editor/scripts/postinstall.ts
@@ -16,13 +16,6 @@ const expectedPackages: {
     pathToCopyFrom: 'min/vs',
     pathToCopyTo: 'vs',
   },
-  'monaco-old': {
-    name: 'monaco-editor-old',
-    version: PACKAGE_VERSIONS['monaco-editor-old'],
-    copyAsName: 'monaco-editor',
-    pathToCopyFrom: 'min/vs',
-    pathToCopyTo: 'vs',
-  },
   officeJs: {
     // Note: this package is now used only for offline development
     name: '@microsoft/office-js',

--- a/packages/editor/src/pages/Editor/components/Main/Editor/ReactMonaco.tsx
+++ b/packages/editor/src/pages/Editor/components/Main/Editor/ReactMonaco.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { HYPHENATED_PACKAGE_VERSIONS } from 'common/lib/package-versions';
-import { Utilities, PlatformType } from '@microsoft/office-js-helpers';
 
 export interface IProps {
   solutionId: string;
@@ -23,25 +22,10 @@ export class ReactMonaco extends Component<IProps, IState> {
     if ((window as any).monaco !== undefined) {
       this.initializeMonaco();
     } else {
-      /* On the Mac Office (but not in regular Safari),
-        never versions of Monaco have a mouse-focus issue
-        (see https://github.com/OfficeDev/script-lab/issues/506 and related) --
-        though on the other hand the older Monaco also has a crashing issue
-        described by https://github.com/OfficeDev/script-lab/issues/514, which
-        isn't great either.
-
-        But in any case, for now, will load an older version of Monaco for Mac,
-        and a newer one for any other platform type
-      */
-      const monacoVersionToLoad =
-        Utilities.platform === PlatformType.MAC
-          ? HYPHENATED_PACKAGE_VERSIONS['monaco-editor-old']
-          : HYPHENATED_PACKAGE_VERSIONS['monaco-editor'];
-
       (window as any).require.config({
         baseUrl: '/',
         paths: {
-          vs: `external/monaco-editor-${monacoVersionToLoad}/vs`,
+          vs: `external/monaco-editor-${HYPHENATED_PACKAGE_VERSIONS['monaco-editor']}/vs`,
         },
       });
       (window as any).require(['vs/editor/editor.main'], () => this.initializeMonaco());
@@ -104,10 +88,7 @@ export class ReactMonaco extends Component<IProps, IState> {
     );
 
   private getUri = () =>
-    new monaco.Uri().with({
-      scheme: 'file',
-      path: `${this.props.solutionId}/${this.props.file.id}`,
-    });
+    monaco.Uri.file(`${this.props.solutionId}/${this.props.file.id}`);
 
   private getModel = () => {
     const uri = this.getUri();

--- a/packages/editor/src/pages/Editor/store/editor/utilities.ts
+++ b/packages/editor/src/pages/Editor/store/editor/utilities.ts
@@ -45,55 +45,55 @@ export function registerLibrariesMonacoLanguage() {
       });
 
       if (Regex.STARTS_WITH_COMMENT.test(currentLine)) {
-        return [];
+        return { suggestions: [] };
       }
 
       if (currentLine === '') {
-        return librariesIntellisenseJSON.map(library => {
-          let insertText = '';
+        return {
+          suggestions: librariesIntellisenseJSON.map(library => {
+            let insertText = '';
 
-          if (Array.isArray(library.value)) {
-            insertText += library.value.join('\n');
-          } else {
-            insertText += library.value || '';
-            insertText += '\n';
-          }
+            if (Array.isArray(library.value)) {
+              insertText += library.value.join('\n');
+            } else {
+              insertText += library.value || '';
+              insertText += '\n';
+            }
 
-          if (Array.isArray(library.typings)) {
-            insertText += (library.typings as string[]).join('\n');
-          } else {
-            insertText += library.typings || '';
-            insertText += '\n';
-          }
+            if (Array.isArray(library.typings)) {
+              insertText += (library.typings as string[]).join('\n');
+            } else {
+              insertText += library.typings || '';
+              insertText += '\n';
+            }
 
-          return {
-            label: library.label,
-            documentation: library.description,
-            kind: monaco.languages.CompletionItemKind.Module,
-            insertText,
-          };
-        });
+            const suggestion: monaco.languages.CompletionItem = {
+              label: library.label,
+              documentation: library.description,
+              kind: monaco.languages.CompletionItemKind.Module,
+              insertText,
+              range: null /*FIXME*/,
+            };
+
+            return suggestion;
+          }),
+        };
       }
 
-      return Promise.resolve([]);
+      return { suggestions: [] };
     },
   });
 }
 
 export function registerSettingsMonacoLanguage() {
+  // Note, this doesn't appear to be working:
+  // Issue tracking it:  https://github.com/OfficeDev/script-lab/issues/656
   monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
     validate: true,
     schemas: [
       {
         uri: SettingsSchema.$id,
-        fileMatch: [
-          new monaco.Uri()
-            .with({
-              scheme: 'file',
-              path: USER_SETTINGS_FILE_ID,
-            })
-            .toString(),
-        ],
+        fileMatch: [monaco.Uri.file(USER_SETTINGS_FILE_ID).toString()],
         schema: SettingsSchema,
       },
     ],

--- a/packages/editor/src/pages/Editor/store/editor/utilities.ts
+++ b/packages/editor/src/pages/Editor/store/editor/utilities.ts
@@ -72,7 +72,8 @@ export function registerLibrariesMonacoLanguage() {
               documentation: library.description,
               kind: monaco.languages.CompletionItemKind.Module,
               insertText,
-              range: null /*FIXME*/,
+              range: null /* range appears to be a required parameter starting in 0.16.0+,
+                but seems OK with null and to default to reasonable behavior */,
             };
 
             return suggestion;

--- a/packages/editor/src/setupTests.ts
+++ b/packages/editor/src/setupTests.ts
@@ -1,9 +1,12 @@
 import 'common/lib/polyfills';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { HYPHENATED_PACKAGE_VERSIONS } from 'common/lib/package-versions';
 
 // tslint:disable-next-line:no-var-requires
-(window as any).require = require('../public/external/monaco-editor-0-14-3/vs/loader');
+(window as any).require = require(`../public/external/monaco-editor-${
+  HYPHENATED_PACKAGE_VERSIONS['monaco-editor']
+}/vs/loader`);
 
 // this is basically: afterEach(cleanup)
 import 'react-testing-library/cleanup-after-each';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8877,15 +8877,10 @@ moment@2.22.2, moment@^2.22.2:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
   integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
-"monaco-editor-old@npm:monaco-editor@0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.10.1.tgz#8c96c4f15b6b5258bf92cbde93cad8a7e3007e14"
-  integrity sha1-jJbE8VtrUli/ksvek8rYp+MAfhQ=
-
-"monaco-editor@npm:monaco-editor@0.14.3":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.14.3.tgz#7cc4a4096a3821f52fea9b10489b527ef3034e22"
-  integrity sha512-RhaO4xXmWn/p0WrkEOXe4PoZj6xOcvDYjoAh0e1kGUrQnP1IOpc0m86Ceuaa2CLEMDINqKijBSmqhvBQnsPLHQ==
+monaco-editor@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.16.0.tgz#83538173c2427f62e0ea3e19a4864742ea457cd9"
+  integrity sha512-a0ZksW1C5gTXOOJR/guKwzYrLJkJtMqzPb/W81YFSFHwbZ/ecVWdNguUkuyUuchzeKJRwqcizgVx++G9wmfofQ==
 
 moo@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
Upgrading to the latest Monaco.
It at minimum fixes #648 and fixes #623.
It should also fix the issue on the Mac, and thus fixes #506.  Will need to validate on the Mac once this is in alpha.

@gergzk , did you mention there is some accessibility tool I need to run after I update to the latest Monaco?  What is it?