### PR TITLE
Use monaco dev version on local and alpha environments

### DIFF
--- a/packages/editor/scripts/postinstall.ts
+++ b/packages/editor/scripts/postinstall.ts
@@ -1,5 +1,13 @@
 import { PACKAGE_VERSIONS, hyphenate } from '../../common/src/package-versions';
 
+const IS_LOCAL_OR_ALPHA_ENV = checkIfLocalOrAlphaEnvironment();
+if (IS_LOCAL_OR_ALPHA_ENV) {
+  console.info(
+    'Running locally or on alpha environment, will use non-minified versions ' +
+      'during postinstall, where appropriate',
+  );
+}
+
 const expectedPackages: {
   [key: string]: {
     name: string;
@@ -13,7 +21,7 @@ const expectedPackages: {
     name: 'monaco-editor',
     version: PACKAGE_VERSIONS['monaco-editor'],
     copyAsName: 'monaco-editor',
-    pathToCopyFrom: 'min/vs',
+    pathToCopyFrom: `${IS_LOCAL_OR_ALPHA_ENV ? 'dev' : 'min'}/vs`,
     pathToCopyTo: 'vs',
   },
   officeJs: {
@@ -94,3 +102,20 @@ for (const key in expectedPackages) {
   fs.removeSync(pair.to);
   fs.copySync(pair.from, pair.to);
 });
+
+///////////////////////////////////////
+
+function checkIfLocalOrAlphaEnvironment() {
+  const { TRAVIS_BRANCH } = process.env; // from travis
+
+  if (!TRAVIS_BRANCH) {
+    // running locally
+    return true;
+  }
+
+  if (TRAVIS_BRANCH === 'master') {
+    return true;
+  }
+
+  return false;
+}

--- a/packages/editor/src/pages/Editor/store/editor/utilities.test.ts
+++ b/packages/editor/src/pages/Editor/store/editor/utilities.test.ts
@@ -1,4 +1,4 @@
-import { Regex } from './utilities';
+import { REGEX } from './utilities';
 
 describe('Editor utilities', () => {
   describe('regexes', () => {
@@ -12,10 +12,12 @@ describe('Editor utilities', () => {
         };
 
         Object.keys(validRefs).forEach((ref: string) => {
-          const tsr = new RegExp(Regex.TRIPLE_SLASH_REF);
+          const tsr = new RegExp(REGEX.TRIPLE_SLASH_REF);
           expect(tsr.exec(ref)).toContain(validRefs[ref]);
         });
       });
     });
   });
 });
+
+// cspell:ignore regexes

--- a/packages/editor/src/pages/Editor/store/editor/utilities.ts
+++ b/packages/editor/src/pages/Editor/store/editor/utilities.ts
@@ -7,7 +7,7 @@ export function doesMonacoExist() {
   return !!(window as any).monaco;
 }
 
-export const Regex = {
+export const REGEX = {
   STARTS_WITH_TYPINGS: /^.types\/.+|^dt~.+/i,
   STARTS_WITH_COMMENT: /^#.*|^\/\/.*|^\/\*.*|.*\*\/$.*/im,
   ENDS_WITH_CSS: /.*\.css$/i,
@@ -25,11 +25,11 @@ export function registerLibrariesMonacoLanguage() {
   monaco.languages.setMonarchTokensProvider('libraries', {
     tokenizer: {
       root: [
-        { regex: Regex.STARTS_WITH_COMMENT, action: { token: 'comment' } },
-        { regex: Regex.ENDS_WITH_CSS, action: { token: 'number' } },
-        { regex: Regex.STARTS_WITH_TYPINGS, action: { token: 'string' } },
-        { regex: Regex.ENDS_WITH_DTS, action: { token: 'string' } },
-        { regex: Regex.GLOBAL, action: { token: 'keyword' } },
+        { regex: REGEX.STARTS_WITH_COMMENT, action: { token: 'comment' } },
+        { regex: REGEX.ENDS_WITH_CSS, action: { token: 'number' } },
+        { regex: REGEX.STARTS_WITH_TYPINGS, action: { token: 'string' } },
+        { regex: REGEX.ENDS_WITH_DTS, action: { token: 'string' } },
+        { regex: REGEX.GLOBAL, action: { token: 'keyword' } },
       ],
     },
     tokenPostfix: '',
@@ -44,7 +44,7 @@ export function registerLibrariesMonacoLanguage() {
         endColumn: position.column,
       });
 
-      if (Regex.STARTS_WITH_COMMENT.test(currentLine)) {
+      if (REGEX.STARTS_WITH_COMMENT.test(currentLine)) {
         return { suggestions: [] };
       }
 
@@ -108,11 +108,11 @@ export interface IPrettierSettings {
 export function enablePrettierInMonaco(prettierSettings: IPrettierSettings) {
   import('prettier/parser-typescript').then(prettierTypeScript => {
     /* Adds Prettier Formatting to Monaco for TypeScript */
-    const PrettierTypeScriptFormatter: monaco.languages.DocumentFormattingEditProvider = {
+    const prettierTypeScriptFormatter: monaco.languages.DocumentFormattingEditProvider = {
       provideDocumentFormattingEdits: (
         document: monaco.editor.ITextModel,
-        options: monaco.languages.FormattingOptions,
-        token: monaco.CancellationToken,
+        _options: monaco.languages.FormattingOptions,
+        _token: monaco.CancellationToken,
       ): monaco.languages.TextEdit[] => {
         const text = document.getValue();
         const formatted = runTypeScriptPrettier(
@@ -132,7 +132,7 @@ export function enablePrettierInMonaco(prettierSettings: IPrettierSettings) {
 
     monaco.languages.registerDocumentFormattingEditProvider(
       'typescript',
-      PrettierTypeScriptFormatter,
+      prettierTypeScriptFormatter,
     );
   });
 }
@@ -168,8 +168,8 @@ function runTypeScriptPrettier(
 }
 
 export function parseTripleSlashRefs(url: string, content: string) {
-  let match = Regex.TRIPLE_SLASH_REF.exec(content);
-  Regex.TRIPLE_SLASH_REF.lastIndex = 0;
+  let match = REGEX.TRIPLE_SLASH_REF.exec(content);
+  REGEX.TRIPLE_SLASH_REF.lastIndex = 0;
   if (!match) {
     return [];
   }
@@ -187,8 +187,8 @@ export function parseTripleSlashRefs(url: string, content: string) {
     additionalUrls.push(newUrl);
     copyContent = copyContent.replace(ref, '');
 
-    match = Regex.TRIPLE_SLASH_REF.exec(copyContent);
-    Regex.TRIPLE_SLASH_REF.lastIndex = 0;
+    match = REGEX.TRIPLE_SLASH_REF.exec(copyContent);
+    REGEX.TRIPLE_SLASH_REF.lastIndex = 0;
   }
 
   return additionalUrls;

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "rules": {
     "member-access": [true, "no-public"],
+    "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
     "member-ordering": false,
     "object-literal-shorthand": false,
     "ordered-imports": false,


### PR DESCRIPTION
Use monaco dev version on local and alpha environments (so that we get a useful stack trace)

Also, added tslint rule for naming conventions to allow prefixing with "_" (to prevent another tslint rule from complaining about unused variables)