### PR TITLE
Fix localhost redirect

### DIFF
--- a/packages/common/src/utilities/environment.redirector.ts
+++ b/packages/common/src/utilities/environment.redirector.ts
@@ -11,9 +11,8 @@ const AMOUNT_OF_TIME_BETWEEN_SUSPICIOUS_LOCALHOST_REDIRECTS = 20000;
 /** Amount of time to wait for the user to click to cancel, before redirecting anyway */
 const AMOUNT_OF_TIME_TO_WAIT_ON_CLICK_TO_CANCEL = 4000;
 
-/** Checks (and redirects) if needs to go to a different environment.
- * Note that this function should be called AFTER Office.onReady,
- *    or else the ability to *cancel a navigation to localhost* will not work on Office Online
+/**
+ * Calls Office.onReady, and also checks (and redirects) if needs to go to a different environment.
  * @param isMainDomain - should be set to true if this is called for
  *    the main domain (e.g., editor domain for Script Lab, rather than the runner).
  *    Put differently, the main domain is the domain that hosts the
@@ -22,7 +21,16 @@ const AMOUNT_OF_TIME_TO_WAIT_ON_CLICK_TO_CANCEL = 4000;
  *    redirecting, OR a promise that will *NEVER* resolve
  *    (getting terminated by the page loading to a different page)
  */
-export async function redirectIfNeeded({
+export async function ensureOfficeReadyAndRedirectIfNeeded({
+  isMainDomain,
+}: {
+  isMainDomain: boolean;
+}): Promise<void> {
+  await Office.onReady();
+  await redirectIfNeeded({ isMainDomain });
+}
+
+async function redirectIfNeeded({
   isMainDomain,
 }: {
   isMainDomain: boolean;

--- a/packages/common/src/utilities/environment.redirector.ts
+++ b/packages/common/src/utilities/environment.redirector.ts
@@ -3,6 +3,7 @@ import { localStorageKeys } from '../constants';
 import { editorUrls, currentEditorUrl } from '../environment';
 import ensureFreshLocalStorage from './ensure.fresh.local.storage';
 import { showSplashScreen } from './splash.screen';
+import { ScriptLabError } from './error';
 
 /** Time threshold for kicking in a "click to cancel" UI on redirects */
 const AMOUNT_OF_TIME_BETWEEN_SUSPICIOUS_LOCALHOST_REDIRECTS = 20000;
@@ -11,17 +12,21 @@ const AMOUNT_OF_TIME_BETWEEN_SUSPICIOUS_LOCALHOST_REDIRECTS = 20000;
 const AMOUNT_OF_TIME_TO_WAIT_ON_CLICK_TO_CANCEL = 4000;
 
 /** Checks (and redirects) if needs to go to a different environment.
+ * Note that this function should be called AFTER Office.onReady,
+ *    or else the ability to *cancel a navigation to localhost* will not work on Office Online
  * @param isMainDomain - should be set to true if this is called for
  *    the main domain (e.g., editor domain for Script Lab, rather than the runner).
  *    Put differently, the main domain is the domain that hosts the
  *    dropdown for switching to other environments.
- * @returns `true` if will be redirecting away
+ * @returns - A promise that will either resolve if it's deemed that the page is NOT
+ *    redirecting, OR a promise that will *NEVER* resolve
+ *    (getting terminated by the page loading to a different page)
  */
 export async function redirectIfNeeded({
   isMainDomain,
 }: {
   isMainDomain: boolean;
-}): Promise<boolean> {
+}): Promise<void> {
   try {
     const params = queryString.parse(window.location.search) as {
       originEnvironment?: string;
@@ -42,7 +47,7 @@ export async function redirectIfNeeded({
       // the user has returned back to the root site)
       if (window.location.href.toLowerCase().indexOf(targetUrl) === 0) {
         window.localStorage.removeItem(localStorageKeys.editor.redirectEnvironmentUrl);
-        return false;
+        return;
       }
 
       // If hasn't quit above, then set the redirect URL into storage
@@ -88,7 +93,7 @@ export async function redirectIfNeeded({
         isMainDomain,
       });
       if (!keepGoingWithRedirect) {
-        return false;
+        return;
       }
 
       if (isMainDomain) {
@@ -108,16 +113,16 @@ export async function redirectIfNeeded({
       ];
       window.location.replace(finalUrlComponents.join(''));
 
-      return true;
+      return new Promise(_resolve => () => {
+        /* don't ever call "resolve", waiting indefinitely until the page navigates away */
+      });
     }
 
     // If reached here, environment is already configured. No need to redirect anywhere.
-    return false;
+    return;
   } catch (e) {
-    console.error('Error redirecting the environments, staying on current page', e);
+    throw new ScriptLabError('Error redirecting to a different environment.', e);
   }
-
-  return false;
 }
 
 export async function redirectEditorToOtherEnvironment(configName: string) {
@@ -163,10 +168,6 @@ async function considerIfReallyWantToRedirect({
   //   to decide if want to try again, versus to cancel the redirect.
   if (isMainDomain && redirectUrl.startsWith('https://localhost')) {
     if (checkIfLastRedirectWasRecent()) {
-      // Need to first call "Office.onReady()" at this stage", or else won't be able to
-      // click anywhere in the UI (and hence won't be able to click "cancel", even if want to)
-      await Office.onReady();
-
       const keepGoing = await new Promise<boolean>(async resolve => {
         const timeout = setTimeout(() => {
           resolve(true); // If haven't clicked cancel yet, resolve to true

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -2,11 +2,6 @@ import 'common/lib/polyfills';
 import { invokeGlobalErrorHandler } from 'common/lib/utilities/splash.screen';
 window.onerror = error => invokeGlobalErrorHandler(error);
 
-import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
-const isRedirectingAwayPromise = redirectIfNeeded({
-  isMainDomain: true /* true for the Editor */,
-});
-
 import './index.css';
 
 ///////////////////////////////////////
@@ -20,17 +15,14 @@ import Pages from './pages';
 import AuthPage from './pages/Auth';
 
 (async () => {
-  const isRedirectingAway = await isRedirectingAwayPromise;
-  if (!isRedirectingAway) {
-    try {
-      const rootElement = document.getElementById('root') as HTMLElement;
+  try {
+    const rootElement = document.getElementById('root') as HTMLElement;
 
-      ReactDOM.render(getReactElementBasedOnQueryParams(), rootElement);
+    ReactDOM.render(getReactElementBasedOnQueryParams(), rootElement);
 
-      unregister(); // need more testing to determine if this can be removed. seems to help with the caching of the html file issues
-    } catch (e) {
-      invokeGlobalErrorHandler(e);
-    }
+    unregister(); // need more testing to determine if this can be removed. seems to help with the caching of the html file issues
+  } catch (e) {
+    invokeGlobalErrorHandler(e);
   }
 })();
 

--- a/packages/editor/src/pages/AddinCommands/index.tsx
+++ b/packages/editor/src/pages/AddinCommands/index.tsx
@@ -6,12 +6,18 @@ import { RunOnLoad } from 'common/lib/components/PageSwitcher/utilities/RunOnLoa
 import { AwaitPromiseThenRender } from 'common/lib/components/PageSwitcher/utilities/AwaitPromiseThenRender';
 import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
 
+import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 import setup from './setup';
 
 const AddinCommands = () => (
   <AwaitPromiseThenRender
     promise={addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS])
       .then(() => Office.onReady())
+      .then(() =>
+        redirectIfNeeded({
+          isMainDomain: true /* true for the Editor */,
+        }),
+      )
       .then(() => hideSplashScreen())}
   >
     <RunOnLoad funcToRun={setup} />

--- a/packages/editor/src/pages/AddinCommands/index.tsx
+++ b/packages/editor/src/pages/AddinCommands/index.tsx
@@ -6,15 +6,14 @@ import { RunOnLoad } from 'common/lib/components/PageSwitcher/utilities/RunOnLoa
 import { AwaitPromiseThenRender } from 'common/lib/components/PageSwitcher/utilities/AwaitPromiseThenRender';
 import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
 
-import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
+import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 import setup from './setup';
 
 const AddinCommands = () => (
   <AwaitPromiseThenRender
     promise={addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS])
-      .then(() => Office.onReady())
       .then(() =>
-        redirectIfNeeded({
+        ensureOfficeReadyAndRedirectIfNeeded({
           isMainDomain: true /* true for the Editor */,
         }),
       )

--- a/packages/editor/src/pages/CustomFunctions/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/index.tsx
@@ -8,7 +8,7 @@ import CustomFunctionsDashboard from './components/CustomFunctionsDashboard';
 import Theme from 'common/lib/components/Theme';
 import { Utilities } from '@microsoft/office-js-helpers';
 import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
-import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
+import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 const CFD = App(CustomFunctionsDashboard);
 
@@ -23,9 +23,8 @@ class CustomFunctionsPage extends React.Component<{}, IState> {
     super(props);
 
     addScriptTags([SCRIPT_URLS.OFFICE_JS_FOR_CUSTOM_FUNCTIONS_DASHBOARD])
-      .then(() => Office.onReady())
       .then(() =>
-        redirectIfNeeded({
+        ensureOfficeReadyAndRedirectIfNeeded({
           isMainDomain: true /* true for the Editor */,
         }),
       )

--- a/packages/editor/src/pages/CustomFunctions/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/index.tsx
@@ -8,6 +8,7 @@ import CustomFunctionsDashboard from './components/CustomFunctionsDashboard';
 import Theme from 'common/lib/components/Theme';
 import { Utilities } from '@microsoft/office-js-helpers';
 import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
+import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 const CFD = App(CustomFunctionsDashboard);
 
@@ -23,6 +24,11 @@ class CustomFunctionsPage extends React.Component<{}, IState> {
 
     addScriptTags([SCRIPT_URLS.OFFICE_JS_FOR_CUSTOM_FUNCTIONS_DASHBOARD])
       .then(() => Office.onReady())
+      .then(() =>
+        redirectIfNeeded({
+          isMainDomain: true /* true for the Editor */,
+        }),
+      )
       .then(() => {
         // Note: though could get the host information from "Office.onReady",
         // the rest of the application thinks of the host value in terms of the

--- a/packages/editor/src/pages/Editor/index.tsx
+++ b/packages/editor/src/pages/Editor/index.tsx
@@ -20,6 +20,7 @@ import {
 import throttle from 'lodash/throttle';
 import { ScriptLabError } from 'common/lib/utilities/error';
 import { invokeGlobalErrorHandler } from 'common/lib/utilities/splash.screen';
+import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 interface IState {
   hasLoadedScripts: boolean;
@@ -33,6 +34,11 @@ class Editor extends Component<{}, IState> {
     super(props);
     addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS, SCRIPT_URLS.MONACO_LOADER])
       .then(() => Office.onReady())
+      .then(() =>
+        redirectIfNeeded({
+          isMainDomain: true /* true for the Editor */,
+        }),
+      )
       .then(() => ensureProperOfficeBuildIfRelevant())
       .then(() => loadStateFromLocalStorage())
       .then(localStorageState => {

--- a/packages/editor/src/pages/Editor/index.tsx
+++ b/packages/editor/src/pages/Editor/index.tsx
@@ -20,7 +20,7 @@ import {
 import throttle from 'lodash/throttle';
 import { ScriptLabError } from 'common/lib/utilities/error';
 import { invokeGlobalErrorHandler } from 'common/lib/utilities/splash.screen';
-import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
+import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 interface IState {
   hasLoadedScripts: boolean;
@@ -33,9 +33,8 @@ class Editor extends Component<{}, IState> {
   constructor(props: any) {
     super(props);
     addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS, SCRIPT_URLS.MONACO_LOADER])
-      .then(() => Office.onReady())
       .then(() =>
-        redirectIfNeeded({
+        ensureOfficeReadyAndRedirectIfNeeded({
           isMainDomain: true /* true for the Editor */,
         }),
       )

--- a/packages/runner/src/index.tsx
+++ b/packages/runner/src/index.tsx
@@ -2,11 +2,6 @@ import 'common/lib/polyfills';
 import { invokeGlobalErrorHandler } from 'common/lib/utilities/splash.screen';
 window.onerror = error => invokeGlobalErrorHandler(error);
 
-import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
-const isRedirectingAwayPromise = redirectIfNeeded({
-  isMainDomain: false /* false for the Runner */,
-});
-
 import './index.css';
 
 ///////////////////////////////////////
@@ -17,12 +12,9 @@ import ReactDOM from 'react-dom';
 import Pages from './pages';
 
 (async () => {
-  const isRedirectingAway = await isRedirectingAwayPromise;
-  if (!isRedirectingAway) {
-    try {
-      ReactDOM.render(<Pages />, document.getElementById('root') as HTMLElement);
-    } catch (e) {
-      invokeGlobalErrorHandler(e);
-    }
+  try {
+    ReactDOM.render(<Pages />, document.getElementById('root') as HTMLElement);
+  } catch (e) {
+    invokeGlobalErrorHandler(e);
   }
 })();

--- a/packages/runner/src/pages/Runner/index.tsx
+++ b/packages/runner/src/pages/Runner/index.tsx
@@ -23,7 +23,7 @@ const Runner = () => (
   <AwaitPromiseThenRender
     promise={addScriptTags([getOfficeJsUrlToLoad()]).then(() =>
       ensureOfficeReadyAndRedirectIfNeeded({
-        isMainDomain: true /* true for the Editor */,
+        isMainDomain: false /* false for the Runner */,
       }),
     )}
   >

--- a/packages/runner/src/pages/Runner/index.tsx
+++ b/packages/runner/src/pages/Runner/index.tsx
@@ -4,7 +4,7 @@ import { parse } from 'query-string';
 import { SCRIPT_URLS } from 'common/lib/constants';
 import { OFFICE_JS_URL_QUERY_PARAMETER_KEY } from 'common/lib/utilities/script-loader/constants';
 import { addScriptTags } from 'common/lib/utilities/script-loader';
-
+import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 import { AwaitPromiseThenRender } from 'common/lib/components/PageSwitcher/utilities/AwaitPromiseThenRender';
 
 import App from './components/App';
@@ -21,7 +21,13 @@ function getOfficeJsUrlToLoad(): string {
 
 const Runner = () => (
   <AwaitPromiseThenRender
-    promise={addScriptTags([getOfficeJsUrlToLoad()]).then(() => Office.onReady())}
+    promise={addScriptTags([getOfficeJsUrlToLoad()])
+      .then(() => Office.onReady())
+      .then(() =>
+        redirectIfNeeded({
+          isMainDomain: true /* true for the Editor */,
+        }),
+      )}
   >
     <App />
   </AwaitPromiseThenRender>

--- a/packages/runner/src/pages/Runner/index.tsx
+++ b/packages/runner/src/pages/Runner/index.tsx
@@ -4,7 +4,7 @@ import { parse } from 'query-string';
 import { SCRIPT_URLS } from 'common/lib/constants';
 import { OFFICE_JS_URL_QUERY_PARAMETER_KEY } from 'common/lib/utilities/script-loader/constants';
 import { addScriptTags } from 'common/lib/utilities/script-loader';
-import { redirectIfNeeded } from 'common/lib/utilities/environment.redirector';
+import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 import { AwaitPromiseThenRender } from 'common/lib/components/PageSwitcher/utilities/AwaitPromiseThenRender';
 
 import App from './components/App';
@@ -21,13 +21,11 @@ function getOfficeJsUrlToLoad(): string {
 
 const Runner = () => (
   <AwaitPromiseThenRender
-    promise={addScriptTags([getOfficeJsUrlToLoad()])
-      .then(() => Office.onReady())
-      .then(() =>
-        redirectIfNeeded({
-          isMainDomain: true /* true for the Editor */,
-        }),
-      )}
+    promise={addScriptTags([getOfficeJsUrlToLoad()]).then(() =>
+      ensureOfficeReadyAndRedirectIfNeeded({
+        isMainDomain: true /* true for the Editor */,
+      }),
+    )}
   >
     <App />
   </AwaitPromiseThenRender>

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,13 @@
 {
   "rules": {
     "member-access": [true, "no-public"],
+    "variable-name": [
+      true,
+      "ban-keywords",
+      "check-format",
+      "allow-leading-underscore",
+      "allow-pascal-case"
+    ],
     "member-ordering": false,
     "object-literal-shorthand": false,
     "ordered-imports": false,


### PR DESCRIPTION
Fixes a previous fix by ensuring that `Office.onReady` has already been called (and that the `redirectIfNeeded` itself only gets called *later in the flow, after `Office.onReady` has already been invoked*).