### PR TITLE
Use common Office.js for all pages, and move redirect logic up.

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -9,8 +9,6 @@ export const SCRIPT_URLS = {
   CUSTOM_FUNCTIONS_RUNNER:
     'https://appsforoffice.microsoft.com/lib/preview/hosted/custom-functions-runtime.js',
   DEFAULT_OFFICE_JS: 'https://appsforoffice.microsoft.com/lib/1/hosted/office.js',
-  OFFICE_JS_FOR_CUSTOM_FUNCTIONS_DASHBOARD:
-    'https://appsforoffice.microsoft.com/lib/beta/hosted/office.js',
   MONACO_LOADER: `/external/monaco-editor-${
     HYPHENATED_PACKAGE_VERSIONS['monaco-editor']
   }/vs/loader.js`,

--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -13,10 +13,18 @@ import queryString from 'query-string';
 
 import Pages from './pages';
 import AuthPage from './pages/Auth';
+import { addScriptTags } from 'common/lib/utilities/script-loader';
+import { SCRIPT_URLS } from 'common/lib/constants';
+import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 (async () => {
   try {
     const rootElement = document.getElementById('root') as HTMLElement;
+
+    await addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS]);
+    await ensureOfficeReadyAndRedirectIfNeeded({
+      isMainDomain: true /* true for the Editor */,
+    });
 
     ReactDOM.render(getReactElementBasedOnQueryParams(), rootElement);
 

--- a/packages/editor/src/pages/AddinCommands/index.tsx
+++ b/packages/editor/src/pages/AddinCommands/index.tsx
@@ -1,26 +1,7 @@
 import React from 'react';
-import { SCRIPT_URLS } from 'common/lib/constants';
-import { addScriptTags } from 'common/lib/utilities/script-loader';
-
 import { RunOnLoad } from 'common/lib/components/PageSwitcher/utilities/RunOnLoad';
-import { AwaitPromiseThenRender } from 'common/lib/components/PageSwitcher/utilities/AwaitPromiseThenRender';
-import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
-
-import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 import setup from './setup';
 
-const AddinCommands = () => (
-  <AwaitPromiseThenRender
-    promise={addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS])
-      .then(() =>
-        ensureOfficeReadyAndRedirectIfNeeded({
-          isMainDomain: true /* true for the Editor */,
-        }),
-      )
-      .then(() => hideSplashScreen())}
-  >
-    <RunOnLoad funcToRun={setup} />
-  </AwaitPromiseThenRender>
-);
+const AddinCommands = () => <RunOnLoad funcToRun={setup} />;
 
 export default AddinCommands;

--- a/packages/editor/src/pages/CustomFunctions/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/index.tsx
@@ -1,6 +1,3 @@
-import { SCRIPT_URLS } from 'common/lib/constants';
-import { addScriptTags } from 'common/lib/utilities/script-loader';
-
 import React from 'react';
 
 import App from './components/App';
@@ -8,7 +5,6 @@ import CustomFunctionsDashboard from './components/CustomFunctionsDashboard';
 import Theme from 'common/lib/components/Theme';
 import { Utilities } from '@microsoft/office-js-helpers';
 import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
-import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 const CFD = App(CustomFunctionsDashboard);
 
@@ -22,20 +18,8 @@ class CustomFunctionsPage extends React.Component<{}, IState> {
   constructor(props) {
     super(props);
 
-    addScriptTags([SCRIPT_URLS.OFFICE_JS_FOR_CUSTOM_FUNCTIONS_DASHBOARD])
-      .then(() =>
-        ensureOfficeReadyAndRedirectIfNeeded({
-          isMainDomain: true /* true for the Editor */,
-        }),
-      )
-      .then(() => {
-        // Note: though could get the host information from "Office.onReady",
-        // the rest of the application thinks of the host value in terms of the
-        // OfficeJsHelpers string for host (which is all-caps).
-        // So go ahead and invoke the helper here to be consistent.
-        this.setState({ host: Utilities.host });
-      })
-      .then(() => hideSplashScreen());
+    this.setState({ host: Utilities.host });
+    hideSplashScreen();
   }
 
   render() {

--- a/packages/editor/src/pages/Editor/index.tsx
+++ b/packages/editor/src/pages/Editor/index.tsx
@@ -20,7 +20,6 @@ import {
 import throttle from 'lodash/throttle';
 import { ScriptLabError } from 'common/lib/utilities/error';
 import { invokeGlobalErrorHandler } from 'common/lib/utilities/splash.screen';
-import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 interface IState {
   hasLoadedScripts: boolean;
@@ -32,12 +31,7 @@ class Editor extends Component<{}, IState> {
 
   constructor(props: any) {
     super(props);
-    addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS, SCRIPT_URLS.MONACO_LOADER])
-      .then(() =>
-        ensureOfficeReadyAndRedirectIfNeeded({
-          isMainDomain: true /* true for the Editor */,
-        }),
-      )
+    addScriptTags([SCRIPT_URLS.MONACO_LOADER])
       .then(() => ensureProperOfficeBuildIfRelevant())
       .then(() => loadStateFromLocalStorage())
       .then(localStorageState => {


### PR DESCRIPTION
This eliminates issue with mismatched/missing redirects on some pages (fixes #674)