### PR TITLE
Fix environment redirects in production

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,7 @@
     // Extension identifier format: ${publisher}.${name}
     "esbenp.prettier-vscode",
     "ms-vscode.vscode-typescript-tslint-plugin",
-    "robertohuertasm.vscode-icons",
+    "vscode-icons-team.vscode-icons",
     "coenraads.bracket-pair-colorizer",
     "wayou.vscode-todo-highlight",
     "streetsidesoftware.code-spell-checker",

--- a/packages/common/src/components/PageSwitcher/index.tsx
+++ b/packages/common/src/components/PageSwitcher/index.tsx
@@ -1,24 +1,52 @@
 import React from 'react';
 
 import { HashRouter, Route, Switch } from 'react-router-dom';
+import { AwaitPromiseThenRender } from './utilities/AwaitPromiseThenRender';
+import { addScriptTags } from '../../utilities/script-loader';
+import { redirectIfNeeded } from '../../utilities/environment.redirector';
 
-interface IProps {
-  pages: { [key: string]: React.ComponentType<any> };
-  paths: { [key: string]: string };
-  defaultComponent: React.ComponentType<any>;
+export interface IPageLoadingSpec {
+  component: React.ComponentType;
+  officeJs: string | null;
+  isRedirectCancelable?: boolean;
 }
 
-const PageSwitcher = ({ pages, paths, defaultComponent }: IProps) => (
+interface IProps {
+  pages: { [key: string]: IPageLoadingSpec };
+  defaultPath: string;
+}
+
+const PageSwitcher = ({ pages, defaultPath }: IProps) => (
   <HashRouter>
     <Switch>
       {/* Render a route for each page */}
-      {Object.keys(pages).map(page => (
-        <Route exact path={paths[page]} component={pages[page]} key={page} />
+      {Object.keys(pages).map(path => (
+        <Route
+          exact
+          path={path}
+          component={renderPageAfterPrerequisites(pages[path])}
+          key={path}
+        />
       ))}
       {/* Falling back on the default component for an unknown route */}
-      <Route component={defaultComponent} />
+      <Route component={renderPageAfterPrerequisites(pages[defaultPath])} />
     </Switch>
   </HashRouter>
 );
 
 export default PageSwitcher;
+
+///////////////////////////////////////
+
+function renderPageAfterPrerequisites(spec: IPageLoadingSpec): React.ComponentType {
+  return () => (
+    <AwaitPromiseThenRender
+      promise={(spec.officeJs
+        ? addScriptTags([spec.officeJs]).then(() => Office.onReady())
+        : Promise.resolve(null)
+      ).then(() => redirectIfNeeded({ isCancelable: spec.isRedirectCancelable }))}
+    >
+      {React.createElement(spec.component)}
+    </AwaitPromiseThenRender>
+  );
+}

--- a/packages/editor/src/pages/AddinCommands/index.tsx
+++ b/packages/editor/src/pages/AddinCommands/index.tsx
@@ -1,26 +1,7 @@
 import React from 'react';
-import { SCRIPT_URLS } from 'common/lib/constants';
-import { addScriptTags } from 'common/lib/utilities/script-loader';
-
 import { RunOnLoad } from 'common/lib/components/PageSwitcher/utilities/RunOnLoad';
-import { AwaitPromiseThenRender } from 'common/lib/components/PageSwitcher/utilities/AwaitPromiseThenRender';
-import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
-
-import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 import setup from './setup';
 
-const AddinCommands = () => (
-  <AwaitPromiseThenRender
-    promise={addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS])
-      .then(() =>
-        ensureOfficeReadyAndRedirectIfNeeded({
-          isMainDomain: true /* true for the Editor */,
-        }),
-      )
-      .then(() => hideSplashScreen())}
-  >
-    <RunOnLoad funcToRun={setup} />
-  </AwaitPromiseThenRender>
-);
+const AddinCommands = () => <RunOnLoad funcToRun={setup} />;
 
 export default AddinCommands;

--- a/packages/editor/src/pages/AddinCommands/setup.ts
+++ b/packages/editor/src/pages/AddinCommands/setup.ts
@@ -37,6 +37,9 @@ export default function setup() {
       }
     }
   });
+
+  // Now that the functions are registered, call Office.onReady()
+  return Office.onReady();
 }
 
 /////////////////////////////////

--- a/packages/editor/src/pages/CustomFunctions/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/index.tsx
@@ -1,6 +1,3 @@
-import { SCRIPT_URLS } from 'common/lib/constants';
-import { addScriptTags } from 'common/lib/utilities/script-loader';
-
 import React from 'react';
 
 import App from './components/App';
@@ -8,7 +5,6 @@ import CustomFunctionsDashboard from './components/CustomFunctionsDashboard';
 import Theme from 'common/lib/components/Theme';
 import { Utilities } from '@microsoft/office-js-helpers';
 import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
-import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 const CFD = App(CustomFunctionsDashboard);
 
@@ -22,20 +18,8 @@ class CustomFunctionsPage extends React.Component<{}, IState> {
   constructor(props) {
     super(props);
 
-    addScriptTags([SCRIPT_URLS.OFFICE_JS_FOR_CUSTOM_FUNCTIONS_DASHBOARD])
-      .then(() =>
-        ensureOfficeReadyAndRedirectIfNeeded({
-          isMainDomain: true /* true for the Editor */,
-        }),
-      )
-      .then(() => {
-        // Note: though could get the host information from "Office.onReady",
-        // the rest of the application thinks of the host value in terms of the
-        // OfficeJsHelpers string for host (which is all-caps).
-        // So go ahead and invoke the helper here to be consistent.
-        this.setState({ host: Utilities.host });
-      })
-      .then(() => hideSplashScreen());
+    this.setState({ host: Utilities.host });
+    hideSplashScreen();
   }
 
   render() {

--- a/packages/editor/src/pages/Editor/index.tsx
+++ b/packages/editor/src/pages/Editor/index.tsx
@@ -20,7 +20,6 @@ import {
 import throttle from 'lodash/throttle';
 import { ScriptLabError } from 'common/lib/utilities/error';
 import { invokeGlobalErrorHandler } from 'common/lib/utilities/splash.screen';
-import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
 
 interface IState {
   hasLoadedScripts: boolean;
@@ -32,12 +31,7 @@ class Editor extends Component<{}, IState> {
 
   constructor(props: any) {
     super(props);
-    addScriptTags([SCRIPT_URLS.DEFAULT_OFFICE_JS, SCRIPT_URLS.MONACO_LOADER])
-      .then(() =>
-        ensureOfficeReadyAndRedirectIfNeeded({
-          isMainDomain: true /* true for the Editor */,
-        }),
-      )
+    addScriptTags([SCRIPT_URLS.MONACO_LOADER])
       .then(() => ensureProperOfficeBuildIfRelevant())
       .then(() => loadStateFromLocalStorage())
       .then(localStorageState => {

--- a/packages/editor/src/pages/index.tsx
+++ b/packages/editor/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import PageSwitcher from 'common/lib/components/PageSwitcher';
+import PageSwitcher, { IPageLoadingSpec } from 'common/lib/components/PageSwitcher';
 import { PATHS } from '../constants';
 
 import Auth from './Auth';
@@ -12,21 +12,48 @@ import Editor from './Editor';
 import External from './External';
 import Heartbeat from './Heartbeat';
 import Run from './Run';
+import { SCRIPT_URLS } from 'common/lib/constants';
 
 // Note: To add a page you must add the path for the page in
-// src/constants.ts and the key must be the same!
-const pages = {
-  Auth,
-  AddinCommands,
-  CustomFunctions,
-  CustomFunctionsHeartbeat,
-  CustomFunctionsRun,
-  Editor,
-  External,
-  Heartbeat,
-  Run,
+// src/constants.ts add it into the structure below:
+const pages: { [key: string]: IPageLoadingSpec } = {
+  [PATHS.Auth]: {
+    component: Auth,
+    officeJs: null /* is a browser-only page for auth, doesn't need Office.js */,
+  },
+  [PATHS.AddinCommands]: {
+    component: AddinCommands,
+    officeJs: SCRIPT_URLS.DEFAULT_OFFICE_JS,
+  },
+  [PATHS.CustomFunctions]: {
+    component: CustomFunctions,
+    officeJs: SCRIPT_URLS.OFFICE_JS_FOR_CUSTOM_FUNCTIONS_DASHBOARD,
+  },
+  [PATHS.CustomFunctionsHeartbeat]: {
+    component: CustomFunctionsHeartbeat,
+    officeJs: null /* runs in an iframe, doesn't need Office.js */,
+  },
+  [PATHS.CustomFunctionsRun]: {
+    component: CustomFunctionsRun,
+    officeJs: null /* does a window.location redirect, doesn't need Office.js */,
+  },
+  [PATHS.Editor]: {
+    component: Editor,
+    isRedirectCancelable: true,
+    officeJs: SCRIPT_URLS.DEFAULT_OFFICE_JS,
+  },
+  [PATHS.External]: {
+    component: External,
+    officeJs: null /* does a window.location redirect, doesn't need Office.js */,
+  },
+  [PATHS.Heartbeat]: {
+    component: Heartbeat,
+    officeJs: null /* runs in an iframe, doesn't need Office.js */,
+  },
+  [PATHS.Run]: {
+    component: Run,
+    officeJs: null /* does a window.location redirect, doesn't need Office.js */,
+  },
 };
 
-export default () => (
-  <PageSwitcher pages={pages} paths={PATHS} defaultComponent={pages.Editor} />
-);
+export default () => <PageSwitcher pages={pages} defaultPath={PATHS.Editor} />;

--- a/packages/editor/src/pages/index.tsx
+++ b/packages/editor/src/pages/index.tsx
@@ -24,6 +24,8 @@ const pages: { [key: string]: IPageLoadingSpec } = {
   [PATHS.AddinCommands]: {
     component: AddinCommands,
     officeJs: SCRIPT_URLS.DEFAULT_OFFICE_JS,
+    skipOfficeOnReady: true /* skip calling "Office.onReady" until the redirect is determined.
+      The component's setup will then call it itself */,
   },
   [PATHS.CustomFunctions]: {
     component: CustomFunctions,

--- a/packages/runner/src/pages/Runner/index.tsx
+++ b/packages/runner/src/pages/Runner/index.tsx
@@ -1,34 +1,6 @@
 import React from 'react';
-
-import { parse } from 'query-string';
-import { SCRIPT_URLS } from 'common/lib/constants';
-import { OFFICE_JS_URL_QUERY_PARAMETER_KEY } from 'common/lib/utilities/script-loader/constants';
-import { addScriptTags } from 'common/lib/utilities/script-loader';
-import { ensureOfficeReadyAndRedirectIfNeeded } from 'common/lib/utilities/environment.redirector';
-import { AwaitPromiseThenRender } from 'common/lib/components/PageSwitcher/utilities/AwaitPromiseThenRender';
-
 import App from './components/App';
 
-function getOfficeJsUrlToLoad(): string {
-  const params = parse(window.location.search) as {
-    [OFFICE_JS_URL_QUERY_PARAMETER_KEY]: string;
-  };
-
-  return (params[OFFICE_JS_URL_QUERY_PARAMETER_KEY] || '').trim().length > 0
-    ? params[OFFICE_JS_URL_QUERY_PARAMETER_KEY]
-    : SCRIPT_URLS.DEFAULT_OFFICE_JS;
-}
-
-const Runner = () => (
-  <AwaitPromiseThenRender
-    promise={addScriptTags([getOfficeJsUrlToLoad()]).then(() =>
-      ensureOfficeReadyAndRedirectIfNeeded({
-        isMainDomain: false /* false for the Runner */,
-      }),
-    )}
-  >
-    <App />
-  </AwaitPromiseThenRender>
-);
+const Runner = () => <App />;
 
 export default Runner;

--- a/packages/runner/src/pages/index.tsx
+++ b/packages/runner/src/pages/index.tsx
@@ -1,18 +1,37 @@
 import React from 'react';
+import { parse } from 'query-string';
 
-import PageSwitcher from 'common/lib/components/PageSwitcher';
+import PageSwitcher, { IPageLoadingSpec } from 'common/lib/components/PageSwitcher';
+import { SCRIPT_URLS } from 'common/lib/constants';
+import { OFFICE_JS_URL_QUERY_PARAMETER_KEY } from 'common/lib/utilities/script-loader/constants';
+
 import { PATHS } from '../constants';
-
 import CustomFunctionsRunner from './CustomFunctionsRunner';
 import Runner from './Runner';
 
 // Note: To add a page you must add the path for the page in
-// src/constants.ts and the key must be the same!
-const pages = {
-  CustomFunctionsRunner,
-  Runner,
+// src/constants.ts add it into the structure below:
+const pages: { [key: string]: IPageLoadingSpec } = {
+  [PATHS.CustomFunctionsRunner]: {
+    component: CustomFunctionsRunner,
+    officeJs: null /* Will load its own custom-functions-runtime script, not Office.js as such */,
+  },
+  [PATHS.Runner]: {
+    component: Runner,
+    officeJs: getOfficeJsUrlToLoad(),
+  },
 };
 
-export default () => (
-  <PageSwitcher pages={pages} paths={PATHS} defaultComponent={pages.Runner} />
-);
+export default () => <PageSwitcher pages={pages} defaultPath={PATHS.Runner} />;
+
+///////////////////////////////////////
+
+function getOfficeJsUrlToLoad(): string {
+  const params = parse(window.location.search) as {
+    [OFFICE_JS_URL_QUERY_PARAMETER_KEY]: string;
+  };
+
+  return (params[OFFICE_JS_URL_QUERY_PARAMETER_KEY] || '').trim().length > 0
+    ? params[OFFICE_JS_URL_QUERY_PARAMETER_KEY]
+    : SCRIPT_URLS.DEFAULT_OFFICE_JS;
+}


### PR DESCRIPTION
The spec specifies which Office.js URL to load (if any), and the PageSwitcher component is then responsible for loading Office.js (if any), and also doing the environment redirect.

Fixes #674