### PR TITLE
Always include @types/custom-functions-runtime anytime you're in Excel

### DIFF
--- a/packages/editor/src/pages/Editor/store/editor/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/editor/sagas.ts
@@ -152,9 +152,9 @@ function* makeAddIntellisenseRequestSaga() {
     return;
   }
 
-  const defaultEverPresentLibs = solution.options.isCustomFunctionsSolution
-    ? ['@types/custom-functions-runtime']
-    : [];
+  const host = yield select(selectors.host.get);
+  const defaultEverPresentLibs =
+    host === 'EXCEL' ? ['@types/custom-functions-runtime'] : [];
 
   const entries = [...defaultEverPresentLibs, ...libraries.content.split('\n')];
 


### PR DESCRIPTION
Today we already had this, but the functionality would only kick in AFTER you were in a custom functions solution (had `@customfunction` marking) AND had switched back and forth to the libraries.  Realistically, though, it does no harm to always be included whenever you're in Excel mode, and it helps with the non-golden-path.