### PR TITLE
Add counter to CF dashboard's console (regression relative to SL 2017)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "ts-node --project scripts/tsconfig.json scripts/clean.ts",
     "build:common": "yarn workspace common build:package",
-    "postinstall": "yarn postinstall:iterate",
+    "postinstall": "yarn clean && yarn postinstall:iterate",
     "postinstall:iterate": "yarn workspace common postinstall && yarn workspace editor postinstall && yarn workspace runner postinstall",
     "pre-ci": "ts-node --project scripts/tsconfig.json scripts/pre-ci.ts",
     "build": "cd packages/editor && yarn build && cd ../server && yarn build",

--- a/packages/common/src/components/PivotBar/index.tsx
+++ b/packages/common/src/components/PivotBar/index.tsx
@@ -13,6 +13,7 @@ export interface IPivotBarItem {
   text?: string;
   iconName?: string;
   testId?: string;
+  itemCount?: number;
 }
 
 export interface IProps {
@@ -81,6 +82,7 @@ class PivotBar extends React.Component<IProps> {
               linkText={item.text}
               itemIcon={item.iconName}
               data-testid={item.testId}
+              itemCount={item.itemCount || undefined}
             />
           ))}
         </Pivot>

--- a/packages/editor/src/pages/CustomFunctions/components/Console/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/components/Console/index.tsx
@@ -12,21 +12,10 @@ export enum ConsoleLogTypes {
 
 interface IProps {
   logs: ILogData[];
-  fetchLogs();
   clearLogs();
 }
 
 class Console extends React.Component<IProps> {
-  private logFetchInterval: any;
-
-  componentDidMount() {
-    this.logFetchInterval = setInterval(this.props.fetchLogs, 250);
-  }
-
-  componentWillUnmount() {
-    clearInterval(this.logFetchInterval);
-  }
-
   render() {
     const { logs, clearLogs } = this.props;
 

--- a/packages/editor/src/pages/CustomFunctions/components/CustomFunctionsDashboard/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/components/CustomFunctionsDashboard/index.tsx
@@ -7,14 +7,19 @@ import Metadata from '../Metadata';
 import Console from '../Console';
 
 import ComingSoon from '../ComingSoon';
-import Welcome from '../Welcome';
 
 import { IPropsToUI as IProps } from '../App';
 
 export class CustomFunctionsDashboard extends React.Component<IProps> {
-  getShouldPromptRefresh = () => {
-    return this.props.customFunctionsSolutionLastModified > this.props.runnerLastUpdated;
-  };
+  private logFetchInterval: any;
+
+  componentDidMount() {
+    this.logFetchInterval = setInterval(this.props.fetchLogs, 250);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.logFetchInterval);
+  }
 
   render() {
     const {
@@ -22,7 +27,6 @@ export class CustomFunctionsDashboard extends React.Component<IProps> {
       isStandalone,
       engineStatus,
       logs,
-      fetchLogs,
       clearLogs,
       error,
     } = this.props;
@@ -35,9 +39,16 @@ export class CustomFunctionsDashboard extends React.Component<IProps> {
           isStandalone={isStandalone}
           hasAny={customFunctionsSummaryItems.length > 0}
           items={{
-            Summary: <Summary items={customFunctionsSummaryItems} error={error} />,
-            Metadata: <Metadata items={customFunctionsSummaryItems} />,
-            Console: <Console logs={logs} fetchLogs={fetchLogs} clearLogs={clearLogs} />,
+            Summary: {
+              component: <Summary items={customFunctionsSummaryItems} error={error} />,
+            },
+            Metadata: {
+              component: <Metadata items={customFunctionsSummaryItems} />,
+            },
+            Console: {
+              component: <Console logs={logs} clearLogs={clearLogs} />,
+              itemCount: logs.length > 0 ? logs.length : undefined,
+            },
           }}
           shouldPromptRefresh={this.getShouldPromptRefresh()}
         />
@@ -46,6 +57,10 @@ export class CustomFunctionsDashboard extends React.Component<IProps> {
       return <ComingSoon />;
     }
   }
+
+  getShouldPromptRefresh = () => {
+    return this.props.customFunctionsSolutionLastModified > this.props.runnerLastUpdated;
+  };
 }
 
 export default CustomFunctionsDashboard;

--- a/packages/editor/src/pages/CustomFunctions/components/Dashboard/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/components/Dashboard/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Header from 'common/lib/components/Header';
 import HeaderFooterLayout from 'common/lib/components/HeaderFooterLayout';
-import PivotBar from 'common/lib/components/PivotBar';
+import PivotBar, { IPivotBarItem } from 'common/lib/components/PivotBar';
 import Only from 'common/lib/components/Only';
 
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
@@ -15,7 +15,12 @@ interface IProps {
   isStandalone: boolean;
   hasAny: boolean;
   shouldPromptRefresh: boolean;
-  items: { [itemName: string]: React.ReactElement<any> };
+  items: {
+    [itemName: string]: {
+      component: React.ReactElement<any>;
+      itemCount?: number;
+    };
+  };
 }
 
 interface IState {
@@ -71,10 +76,13 @@ class Dashboard extends React.Component<IProps, IState> {
             <Header items={headerItems} />
             <Only when={hasAny}>
               <PivotBar
-                items={Object.keys(items).map(key => ({
-                  key,
-                  text: key,
-                }))}
+                items={Object.keys(items).map(
+                  (key): IPivotBarItem => ({
+                    key,
+                    text: key,
+                    itemCount: items[key].itemCount,
+                  }),
+                )}
                 selectedKey={selectedKey}
                 onSelect={this.setSelectedKey}
               />
@@ -102,7 +110,7 @@ class Dashboard extends React.Component<IProps, IState> {
           ) : null}
 
           {hasAny ? (
-            <ColumnFlexContainer>{items[selectedKey]}</ColumnFlexContainer>
+            <ColumnFlexContainer>{items[selectedKey].component}</ColumnFlexContainer>
           ) : (
             <Welcome isRefreshEnabled={shouldPromptRefresh} />
           )}


### PR DESCRIPTION
Fixes #499

The UI experience looks like this:

![image](https://user-images.githubusercontent.com/2230453/55763579-5ef1cd80-5a1c-11e9-9ac6-db720e402eba.png)
