### PR TITLE
Support YAML-based settings instead of JSON

### DIFF
--- a/packages/editor/src/constants.ts
+++ b/packages/editor/src/constants.ts
@@ -1,7 +1,7 @@
 export const SETTINGS_SOLUTION_ID = 'user-settings';
 export const USER_SETTINGS_FILE_ID = 'user-settings-file';
 export const DEFAULT_SETTINGS_FILE_ID = 'default-settings-file';
-export const SETTINGS_JSON_LANGUAGE = 'JSON';
+export const SETTINGS_JSON_LANGUAGE = 'YAML';
 export const ABOUT_FILE_ID = 'about';
 
 export const NULL_FILE_ID = 'null-file';

--- a/packages/editor/src/pages/Editor/store/settings/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/settings/sagas.ts
@@ -64,6 +64,8 @@ export const verifySettings = (parsed): Partial<ISettings> => {
 
 function* editSettingsCheckSaga(action: ActionType<typeof settingsActions.editFile>) {
   try {
+    // First off, check whether the new settings are actually empty.
+    // If they are, do special processing, since you can't safeLoad from an empty string.
     const isEmpty = action.payload.newSettings.trim() === '';
     const newSettings = isEmpty
       ? {}
@@ -75,6 +77,8 @@ function* editSettingsCheckSaga(action: ActionType<typeof settingsActions.editFi
       USER_SETTINGS_FILE_ID,
     );
 
+    // safeDump of an empty object gives you the JSON object `{}`, whereas what we want
+    //    in this case is just an empty string. So make it so:
     currentUserSettingsFile.content = isEmpty
       ? ''
       : YAML.safeDump(newSettings, { indent: tabSize });

--- a/packages/editor/src/pages/Editor/store/settings/sagas.ts
+++ b/packages/editor/src/pages/Editor/store/settings/sagas.ts
@@ -1,5 +1,6 @@
 import { put, takeEvery, call, select } from 'redux-saga/effects';
 import { getType, ActionType } from 'typesafe-actions';
+import YAML from 'js-yaml';
 
 import {
   settings as settingsActions,
@@ -11,7 +12,7 @@ import selectors from '../selectors';
 
 import isEqual from 'lodash/isEqual';
 
-import { allowedSettings, defaultSettings } from './utilities';
+import { allowedSettings, defaultSettings, invisibleDefaultSettings } from './utilities';
 
 import {
   SETTINGS_SOLUTION_ID,
@@ -26,8 +27,11 @@ export default function* settingsWatcher() {
   yield takeEvery(getType(settingsActions.cycleEditorTheme), cycleEditorThemeSaga);
 }
 
-export const verifySettings = parsed => {
-  const validKeys = Object.keys(defaultSettings);
+export const verifySettings = (parsed): Partial<ISettings> => {
+  const validKeys = [
+    ...Object.keys(defaultSettings),
+    ...Object.keys(invisibleDefaultSettings),
+  ];
   const parsedKeys = Object.keys(parsed);
   const allowedValueKeys = Object.keys(allowedSettings);
 
@@ -44,7 +48,12 @@ export const verifySettings = parsed => {
       !allowedSettings[setting].includes(parsed[setting])
     ) {
       /* In this case, there was a setting in parsed that wasn't in the list of allowed */
-      throw new Error(`'${parsed[setting]}' is not an allowed value for '${setting}'.`);
+      throw new Error(
+        `'${parsed[setting]}' is not an allowed value for '${setting}'. ` +
+          `Allowed values include: ${allowedSettings[setting]
+            .map((item: string) => `"${item}"`)
+            .join(', ')}.`,
+      );
     } else {
       newSettings[setting] = parsed[setting];
     }
@@ -54,28 +63,21 @@ export const verifySettings = parsed => {
 };
 
 function* editSettingsCheckSaga(action: ActionType<typeof settingsActions.editFile>) {
-  if (action.payload.newSettings.trim() === '') {
-    yield put(
-      editorActions.openFile({
-        solutionId: SETTINGS_SOLUTION_ID,
-        fileId: DEFAULT_SETTINGS_FILE_ID,
-      }),
-    );
-    return;
-  }
-
   try {
-    const parsed = JSON.parse(action.payload.newSettings);
-
-    const newSettings = verifySettings(parsed);
-
+    const isEmpty = action.payload.newSettings.trim() === '';
+    const newSettings = isEmpty
+      ? {}
+      : verifySettings(YAML.safeLoad(action.payload.newSettings));
     const tabSize = { ...defaultSettings, ...newSettings }['editor.tabSize'];
 
-    const currentUserSettingsFile = yield select(
+    const currentUserSettingsFile: IFile = yield select(
       selectors.solutions.getFile,
       USER_SETTINGS_FILE_ID,
     );
-    currentUserSettingsFile.content = JSON.stringify(newSettings, null, tabSize);
+
+    currentUserSettingsFile.content = isEmpty
+      ? ''
+      : YAML.safeDump(newSettings, { indent: tabSize });
     yield put(settingsActions.edit.success({ userSettings: newSettings }));
     yield put(
       solutionsActions.edit({

--- a/packages/editor/src/pages/Editor/store/settings/utilities.ts
+++ b/packages/editor/src/pages/Editor/store/settings/utilities.ts
@@ -1,3 +1,5 @@
+import YAML from 'js-yaml';
+
 import {
   SETTINGS_SOLUTION_ID,
   USER_SETTINGS_FILE_ID,
@@ -20,6 +22,8 @@ export const defaultSettings: ISettings = {
   'editor.wordWrap': 'bounded',
 };
 
+export const invisibleDefaultSettings: { [key: string]: any } = {};
+
 const getTabSize = (userSettings: Partial<ISettings>): number =>
   userSettings && userSettings['editor.tabSize']
     ? userSettings['editor.tabSize']!
@@ -27,12 +31,16 @@ const getTabSize = (userSettings: Partial<ISettings>): number =>
 
 const getDefaultSettingsContent = (userSettings: Partial<ISettings>): string => {
   const tabSize = getTabSize(userSettings);
-  return JSON.stringify(defaultSettings, null, tabSize) + '\n';
+  return YAML.safeDump(defaultSettings, { indent: tabSize });
 };
 
 const getUserSettingsContent = (userSettings: Partial<ISettings>): string => {
+  if (Object.keys(userSettings).length === 0) {
+    return '';
+  }
+
   const tabSize = getTabSize(userSettings);
-  return JSON.stringify(userSettings, null, tabSize) + '\n';
+  return YAML.safeDump(userSettings, { indent: tabSize });
 };
 
 const getAboutContent = (): string => {


### PR DESCRIPTION
Fixes #539
This makes for much easier usability when copy-pasting setttings (no errors about trailing commas, etc.).  And is necessary for upcoming work (e.g., experimental features)