### PR TITLE
Master => Beta

### DIFF
--- a/packages/editor/src/constants.ts
+++ b/packages/editor/src/constants.ts
@@ -1,7 +1,7 @@
 export const SETTINGS_SOLUTION_ID = 'user-settings';
 export const USER_SETTINGS_FILE_ID = 'user-settings-file';
 export const DEFAULT_SETTINGS_FILE_ID = 'default-settings-file';
-export const SETTINGS_JSON_LANGUAGE = 'JSON';
+export const SETTINGS_JSON_LANGUAGE = 'YAML';
 export const ABOUT_FILE_ID = 'about';
 
 export const NULL_FILE_ID = 'null-file';

--- a/packages/editor/src/pages/Editor/store/settings/utilities.ts
+++ b/packages/editor/src/pages/Editor/store/settings/utilities.ts
@@ -1,3 +1,5 @@
+import YAML from 'js-yaml';
+
 import {
   SETTINGS_SOLUTION_ID,
   USER_SETTINGS_FILE_ID,
@@ -20,6 +22,8 @@ export const defaultSettings: ISettings = {
   'editor.wordWrap': 'bounded',
 };
 
+export const invisibleDefaultSettings: { [key: string]: any } = {};
+
 const getTabSize = (userSettings: Partial<ISettings>): number =>
   userSettings && userSettings['editor.tabSize']
     ? userSettings['editor.tabSize']!
@@ -27,12 +31,16 @@ const getTabSize = (userSettings: Partial<ISettings>): number =>
 
 const getDefaultSettingsContent = (userSettings: Partial<ISettings>): string => {
   const tabSize = getTabSize(userSettings);
-  return JSON.stringify(defaultSettings, null, tabSize) + '\n';
+  return YAML.safeDump(defaultSettings, { indent: tabSize });
 };
 
 const getUserSettingsContent = (userSettings: Partial<ISettings>): string => {
+  if (Object.keys(userSettings).length === 0) {
+    return '';
+  }
+
   const tabSize = getTabSize(userSettings);
-  return JSON.stringify(userSettings, null, tabSize) + '\n';
+  return YAML.safeDump(userSettings, { indent: tabSize });
 };
 
 const getAboutContent = (): string => {


### PR DESCRIPTION
Fixes #539
This makes for much easier usability when copy-pasting settings (no errors about trailing commas, etc.).  And is necessary for upcoming work (e.g., experimental features)