### PR TITLE
Ensure obj is not null before calling .toJSON

### DIFF
--- a/packages/common/src/components/Console/CustomTailoredObjectInspector.tsx
+++ b/packages/common/src/components/Console/CustomTailoredObjectInspector.tsx
@@ -10,7 +10,7 @@ export interface IProps {
 class CustomTailoredObjectInspector extends PureComponent<IProps> {
   render() {
     const { obj } = this.props;
-    if ((obj as any).toJSON) {
+    if (obj && (obj as any).toJSON) {
       return <ObjectInspector data={(obj as any).toJSON()} />;
     } else if (
       typeof OfficeExtension !== 'undefined' &&


### PR DESCRIPTION
Running a script with a `console.log(null)` was causing the program to crash. Turns out this was because we were trying to call `.toJSON` on the object (which was, in this case, `null`).
This just adds a quick check to ensure obj exists before calling `.toJSON`.

Closes #732