### PR TITLE
On switching file language, re-create model

### DIFF
--- a/packages/editor/src/pages/Editor/components/Main/Editor/ReactMonaco.tsx
+++ b/packages/editor/src/pages/Editor/components/Main/Editor/ReactMonaco.tsx
@@ -50,7 +50,7 @@ export class ReactMonaco extends Component<IProps, IState> {
 
         if (isDifferentLanguage) {
           const oldModel = monaco.editor.getModel(
-            getUriForSolutionAndFileCombo({
+            getUri({
               solutionId: solutionId,
               file: prevProps.file,
             }),
@@ -100,14 +100,14 @@ export class ReactMonaco extends Component<IProps, IState> {
       this.editor.getModel().getValue(),
     );
 
-  private getUri = () =>
-    getUriForSolutionAndFileCombo({
+  private getCurrentUri = () =>
+    getUri({
       solutionId: this.props.solutionId,
       file: this.props.file,
     });
 
   private getModel = () => {
-    const uri = this.getUri();
+    const uri = this.getCurrentUri();
     const model = monaco.editor.getModel(uri);
 
     return model
@@ -126,13 +126,7 @@ export class ReactMonaco extends Component<IProps, IState> {
   }
 }
 
-function getUriForSolutionAndFileCombo({
-  solutionId,
-  file,
-}: {
-  solutionId: string;
-  file: IFile;
-}) {
+function getUri({ solutionId, file }: { solutionId: string; file: IFile }) {
   return monaco.Uri.file(`${solutionId}/${file.language}/${file.id}`);
 }
 

--- a/packages/editor/src/pages/Editor/components/Main/Editor/ReactMonaco.tsx
+++ b/packages/editor/src/pages/Editor/components/Main/Editor/ReactMonaco.tsx
@@ -41,11 +41,22 @@ export class ReactMonaco extends Component<IProps, IState> {
         this.clearAllModels();
       }
 
-      if (file.id !== prevProps.file.id) {
+      const isDifferentLanguage = file.language !== prevProps.file.language;
+      if (file.id !== prevProps.file.id || isDifferentLanguage) {
         const newModel = this.getModel();
         newModel.updateOptions({ tabSize: this.props.tabSize });
         this.editor.setModel(newModel);
         this.props.applyFormatting();
+
+        if (isDifferentLanguage) {
+          const oldModel = monaco.editor.getModel(
+            getUriForSolutionAndFileCombo({
+              solutionId: solutionId,
+              file: prevProps.file,
+            }),
+          );
+          oldModel.dispose();
+        }
       }
     }
   }
@@ -90,7 +101,10 @@ export class ReactMonaco extends Component<IProps, IState> {
     );
 
   private getUri = () =>
-    monaco.Uri.file(`${this.props.solutionId}/${this.props.file.id}`);
+    getUriForSolutionAndFileCombo({
+      solutionId: this.props.solutionId,
+      file: this.props.file,
+    });
 
   private getModel = () => {
     const uri = this.getUri();
@@ -110,6 +124,16 @@ export class ReactMonaco extends Component<IProps, IState> {
       <div ref={this.container} style={{ width: '100%', height: '100%' }} role="main" />
     );
   }
+}
+
+function getUriForSolutionAndFileCombo({
+  solutionId,
+  file,
+}: {
+  solutionId: string;
+  file: IFile;
+}) {
+  return monaco.Uri.file(`${solutionId}/${file.language}/${file.id}`);
 }
 
 export default ReactMonaco;


### PR DESCRIPTION
Fixes intellisense / prettier firing for Python as if it's still TS

This is an alternate fix for #752 