### PR TITLE
Adds SupportsSharedFolders element for Outlook manifest

### DIFF
--- a/manifests/script-lab-react-alpha.outlook.xml
+++ b/manifests/script-lab-react-alpha.outlook.xml
@@ -192,6 +192,7 @@
             <Hosts>
                 <Host xsi:type="MailHost">
                     <DesktopFormFactor>
+                        <SupportsSharedFolders>true</SupportsSharedFolders>
                         <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
                             <OfficeTab id="TabDefault">
                                 <Group id="PG.PlayGroup.AA">


### PR DESCRIPTION
Adds SupportsSharedFolders element so add-in could be run for delegate scenarios