### PR TITLE
Add ItemChanged event handlder for Outlook script code

### DIFF
--- a/packages/runner/src/constants.ts
+++ b/packages/runner/src/constants.ts
@@ -27,3 +27,11 @@ export const PATHS = {
   CustomFunctionsRunner: '/custom-functions',
   Runner: '/',
 };
+
+export const itemChangedEventHandler = {
+  name: 'itemChangedEventHandler',
+  host: 'Outlook',
+  content: `Office.context.mailbox.addHandlerAsync(Office.EventType.ItemChanged, itemChanged);
+    function itemChanged(eventArgs) {    
+    }`
+}

--- a/packages/runner/src/constants.ts
+++ b/packages/runner/src/constants.ts
@@ -33,5 +33,5 @@ export const itemChangedEventHandler = {
   host: 'Outlook',
   content: `Office.context.mailbox.addHandlerAsync(Office.EventType.ItemChanged, itemChanged);
     function itemChanged(eventArgs) {    
-    }`
-}
+    }`,
+};

--- a/packages/runner/src/pages/Runner/components/SnippetContainer/index.tsx
+++ b/packages/runner/src/pages/Runner/components/SnippetContainer/index.tsx
@@ -8,7 +8,7 @@ import errorTemplate from './templates/error';
 import noSnippetTemplate from './templates/noSnippet';
 import pythonTemplate from './templates/python';
 
-import { itemChangedEventHandler, officeNamespacesForIframe } from '../../../../constants';
+import * as constants from '../../../../constants';
 import { ProgressIndicator } from 'office-ui-fabric-react/lib/ProgressIndicator';
 import { compileTypeScript, SyntaxError } from './utilities';
 import untrusted from './templates/untrusted';
@@ -116,9 +116,13 @@ class Snippet extends React.Component<IProps, IState> {
       }
 
       // If the host is Outlook, add an ItemChanged event handler if one doesn't exist already
-      if (Utilities.host == HostType.OUTLOOK && (script.language === languageMapLowercased.typescript
-        || script.language === languageMapLowercased.javascript) && script.content.indexOf('Office.EventType.ItemChanged') === -1) {
-        script.content = script.content + itemChangedEventHandler.content;
+      if (
+        Utilities.host == HostType.OUTLOOK &&
+        (script.language === languageMapLowercased.typescript ||
+          script.language === languageMapLowercased.javascript) &&
+        script.content.indexOf('Office.EventType.ItemChanged') === -1
+      ) {
+        script.content = script.content + constants.itemChangedEventHandler.content;
       }
 
       // For the HTML, run it through the browser's DOM parser to get it to auto-add
@@ -189,7 +193,7 @@ class Snippet extends React.Component<IProps, IState> {
               ref={this.iframeRef}
               content={this.state.content}
               lastRendered={this.state.lastRendered}
-              namespacesToTransferFromWindow={officeNamespacesForIframe}
+              namespacesToTransferFromWindow={constants.officeNamespacesForIframe}
               onRenderComplete={this.completeLoad}
               sendMessageFromRunnerToEditor={this.props.sendMessageFromRunnerToEditor}
             />

--- a/packages/runner/src/pages/Runner/components/SnippetContainer/index.tsx
+++ b/packages/runner/src/pages/Runner/components/SnippetContainer/index.tsx
@@ -8,7 +8,7 @@ import errorTemplate from './templates/error';
 import noSnippetTemplate from './templates/noSnippet';
 import pythonTemplate from './templates/python';
 
-import { officeNamespacesForIframe } from '../../../../constants';
+import { itemChangedEventHandler, officeNamespacesForIframe } from '../../../../constants';
 import { ProgressIndicator } from 'office-ui-fabric-react/lib/ProgressIndicator';
 import { compileTypeScript, SyntaxError } from './utilities';
 import untrusted from './templates/untrusted';
@@ -113,6 +113,12 @@ class Snippet extends React.Component<IProps, IState> {
       const script = findScript(solution);
       if (script.language === languageMapLowercased.python) {
         return pythonTemplate({ script: script.content });
+      }
+
+      // If the host is Outlook, add an ItemChanged event handler if one doesn't exist already
+      if (Utilities.host == HostType.OUTLOOK && (script.language === languageMapLowercased.typescript
+        || script.language === languageMapLowercased.javascript) && script.content.indexOf('Office.EventType.ItemChanged') === -1) {
+        script.content = script.content + itemChangedEventHandler.content;
       }
 
       // For the HTML, run it through the browser's DOM parser to get it to auto-add


### PR DESCRIPTION
- This fixes https://github.com/OfficeDev/script-lab/issues/704
- It’s debatable where’s the best place to add the ItemChanged event handler, but I opted to add it in the getContent method in the Runner.  The getContent method gets the script content, which can come from the Editor or from a previously loaded snippet, and then compiles the script.  After we get the initial script, I have added a check to see if the host is Outlook and if the ItemChanged event handler already hasn’t been added to the script.  If both these conditions are met, the code will then append the ItemChangedEventHandler to the script before the script is compiled: