### PR TITLE
Fix code and tutorial functions for owa

### DIFF
--- a/packages/common/src/utilities/popout.control.ts
+++ b/packages/common/src/utilities/popout.control.ts
@@ -41,7 +41,7 @@ export function shouldShowPopoutControl(context: 'editor' | 'runner'): boolean {
 }
 
 export function openPopoutCodeEditor(
-  { onSuccess }: { onSuccess: () => void } = { onSuccess: () => {} },
+  { onSuccess }: { onSuccess: () => void } = { onSuccess: () => { } },
 ) {
   Office.context.ui.displayDialogAsync(
     getPopoutEditorUrl(),
@@ -58,6 +58,32 @@ export function openPopoutCodeEditor(
         invokeGlobalErrorHandler(
           new ScriptLabError(
             'Could not open a standalone code editor window: ' + result.error.message,
+          ),
+        );
+      }
+    },
+  );
+}
+
+export function openPopoutTutorial(
+  tutorialUrl: string,
+  { onSuccess }: { onSuccess: () => void } = { onSuccess: () => { } },
+) {
+  Office.context.ui.displayDialogAsync(
+    tutorialUrl,
+    {
+      height: 60,
+      width: 60,
+      promptBeforeOpen: false,
+    },
+    (result: Office.AsyncResult<any>) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        onSuccess();
+      } else {
+        console.error(result);
+        invokeGlobalErrorHandler(
+          new ScriptLabError(
+            'Could not open a standalone tutorial window: ' + result.error.message,
           ),
         );
       }

--- a/packages/common/src/utilities/popout.control.ts
+++ b/packages/common/src/utilities/popout.control.ts
@@ -41,7 +41,7 @@ export function shouldShowPopoutControl(context: 'editor' | 'runner'): boolean {
 }
 
 export function openPopoutCodeEditor(
-  { onSuccess }: { onSuccess: () => void } = { onSuccess: () => { } },
+  { onSuccess }: { onSuccess: () => void } = { onSuccess: () => {} },
 ) {
   Office.context.ui.displayDialogAsync(
     getPopoutEditorUrl(),
@@ -67,7 +67,7 @@ export function openPopoutCodeEditor(
 
 export function openPopoutTutorial(
   tutorialUrl: string,
-  { onSuccess }: { onSuccess: () => void } = { onSuccess: () => { } },
+  { onSuccess }: { onSuccess: () => void } = { onSuccess: () => {} },
 ) {
   Office.context.ui.displayDialogAsync(
     tutorialUrl,

--- a/packages/editor/src/pages/AddinCommands/setup.ts
+++ b/packages/editor/src/pages/AddinCommands/setup.ts
@@ -9,7 +9,7 @@ export default function setup() {
   //   If you need to change this logic and test locally, sideload the localhost version.
 
   registerCommand('launchCode', event => {
-    if (Utilities.host === HostType.OUTLOOK && Utilities.platform == PlatformType.OFFICE_ONLINE) {
+    if (shouldOpenPopout()) {
       return openPopoutCodeEditor();
     } else {
       return launchInDialog(codeUrl, event, { width: 75, height: 75, displayInIframe: false });
@@ -17,7 +17,7 @@ export default function setup() {
   });
 
   registerCommand('launchTutorial', event => {
-    if (Utilities.host === HostType.OUTLOOK && Utilities.platform == PlatformType.OFFICE_ONLINE) {
+    if (shouldOpenPopout()) {
       return openPopoutTutorial(tutorialUrl);
     } else {
       return launchInDialog(tutorialUrl, event, { width: 35, height: 45 });
@@ -136,4 +136,8 @@ function launchInStandaloneWindow(url: string, event: any): void {
       );
     },
   );
+}
+
+function shouldOpenPopout(): boolean {
+  return Utilities.host === HostType.OUTLOOK && Utilities.platform == PlatformType.OFFICE_ONLINE;
 }

--- a/packages/editor/src/pages/AddinCommands/setup.ts
+++ b/packages/editor/src/pages/AddinCommands/setup.ts
@@ -1,6 +1,6 @@
 import { Utilities, HostType, PlatformType } from '@microsoft/office-js-helpers';
 import safeExternalUrls from 'common/lib/safe.external.urls';
-import { openPopoutCodeEditor, openPopoutTutorial } from 'common/lib/utilities/popout.control';
+import * as popoutControl from 'common/lib/utilities/popout.control';
 
 export default function setup() {
   // SUPER IMPORTANT NOTE:  The add-in commands code doesn't do a redirect to localhost
@@ -10,15 +10,19 @@ export default function setup() {
 
   registerCommand('launchCode', event => {
     if (shouldOpenPopout()) {
-      return openPopoutCodeEditor();
+      return popoutControl.openPopoutCodeEditor();
     } else {
-      return launchInDialog(codeUrl, event, { width: 75, height: 75, displayInIframe: false });
+      return launchInDialog(codeUrl, event, {
+        width: 75,
+        height: 75,
+        displayInIframe: false,
+      });
     }
   });
 
   registerCommand('launchTutorial', event => {
     if (shouldOpenPopout()) {
-      return openPopoutTutorial(tutorialUrl);
+      return popoutControl.openPopoutTutorial(tutorialUrl);
     } else {
       return launchInDialog(tutorialUrl, event, { width: 35, height: 45 });
     }
@@ -139,5 +143,8 @@ function launchInStandaloneWindow(url: string, event: any): void {
 }
 
 function shouldOpenPopout(): boolean {
-  return Utilities.host === HostType.OUTLOOK && Utilities.platform == PlatformType.OFFICE_ONLINE;
+  return (
+    Utilities.host === HostType.OUTLOOK &&
+    Utilities.platform == PlatformType.OFFICE_ONLINE
+  );
 }

--- a/packages/editor/src/pages/AddinCommands/setup.ts
+++ b/packages/editor/src/pages/AddinCommands/setup.ts
@@ -1,5 +1,6 @@
-import { Utilities, HostType } from '@microsoft/office-js-helpers';
+import { Utilities, HostType, PlatformType } from '@microsoft/office-js-helpers';
 import safeExternalUrls from 'common/lib/safe.external.urls';
+import { openPopoutCodeEditor, openPopoutTutorial } from 'common/lib/utilities/popout.control';
 
 export default function setup() {
   // SUPER IMPORTANT NOTE:  The add-in commands code doesn't do a redirect to localhost
@@ -7,13 +8,21 @@ export default function setup() {
   //   This is controlled by `skipRedirect: true` in `packages/editor/src/pages/index.tsx`.
   //   If you need to change this logic and test locally, sideload the localhost version.
 
-  registerCommand('launchCode', event =>
-    launchInDialog(codeUrl, event, { width: 75, height: 75, displayInIframe: false }),
-  );
+  registerCommand('launchCode', event => {
+    if (Utilities.host === HostType.OUTLOOK && Utilities.platform == PlatformType.OFFICE_ONLINE) {
+      return openPopoutCodeEditor();
+    } else {
+      return launchInDialog(codeUrl, event, { width: 75, height: 75, displayInIframe: false });
+    }
+  });
 
-  registerCommand('launchTutorial', event =>
-    launchInDialog(tutorialUrl, event, { width: 35, height: 45 }),
-  );
+  registerCommand('launchTutorial', event => {
+    if (Utilities.host === HostType.OUTLOOK && Utilities.platform == PlatformType.OFFICE_ONLINE) {
+      return openPopoutTutorial(tutorialUrl);
+    } else {
+      return launchInDialog(tutorialUrl, event, { width: 35, height: 45 });
+    }
+  });
 
   registerCommand('launchHelp', event =>
     launchInStandaloneWindow(safeExternalUrls.playground_help, event),


### PR DESCRIPTION
If the manifest contains buttons that invoke launchCode and launchTutorial, the dialogs failed to open in OWA.

The fix is to invoke pop-out dialogs for the launchCode and launchTutorial if the Host is Outlook and the Platform is Office_Online

- Added new openPopoutTutorial method to popout.control.ts
- Added shouldOpenPopout method to setup.ts