### PR TITLE
Change size for IconUrl for Outlook

### DIFF
--- a/manifests/script-lab-react-localhost.outlook.xml
+++ b/manifests/script-lab-react-localhost.outlook.xml
@@ -9,7 +9,7 @@
     <DefaultLocale>en-US</DefaultLocale>
     <DisplayName DefaultValue="[Dev] Script Lab for Outlook" />
     <Description DefaultValue="Create, run, and share your Office Add-in code snippets from within Outlook."></Description>
-    <IconUrl DefaultValue="https://localhost:3000/assets/images/icon-32.png" />
+    <IconUrl DefaultValue="https://localhost:3000/assets/images/icon-64.png" />
     <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/images/icon-64.png" />
     <SupportUrl DefaultValue="https://github.com/OfficeDev/script-lab/issues" />
     <AppDomains>

--- a/manifests/script-lab-react-prod.outlook.xml
+++ b/manifests/script-lab-react-prod.outlook.xml
@@ -9,7 +9,7 @@
     <DefaultLocale>en-US</DefaultLocale>
     <DisplayName DefaultValue="Script Lab for Outlook" />
     <Description DefaultValue="Create, run, and share your Office Add-in code snippets from within Outlook."></Description>
-    <IconUrl DefaultValue="https://script-lab.azureedge.net/assets/images/icon-32.png" />
+    <IconUrl DefaultValue="https://script-lab.azureedge.net/assets/images/icon-64.png" />
     <HighResolutionIconUrl DefaultValue="https://script-lab.azureedge.net/assets/images/icon-64.png" />
     <SupportUrl DefaultValue="https://github.com/OfficeDev/script-lab/issues" />
     <AppDomains>


### PR DESCRIPTION
- Recommended size for Outlook url is different than for other hosts:  https://docs.microsoft.com/en-us/office/dev/add-ins/reference/manifest/iconurl