### PR TITLE
Roll back manifest no custom tabs

### DIFF
--- a/manifests/script-lab-react-localhost.outlook.xml
+++ b/manifests/script-lab-react-localhost.outlook.xml
@@ -183,137 +183,550 @@
         </Resources>
         <!-- Version Overrides 1.1-->
         <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
-            <Requirements>
-                <bt:Sets DefaultMinVersion="1.3">
-                    <bt:Set Name="Mailbox"/>
-                </bt:Sets>
-            </Requirements>
-            <Hosts>
-                <Host xsi:type="MailHost">
-                    <DesktopFormFactor>
-                        <SupportsSharedFolders>true</SupportsSharedFolders>
-                        <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
-                            <OfficeTab id="TabDefault">
-                                <Group id="PG.PlayGroup.AA">
-                                    <Label resid="PG.GroupLabel"/>
-                                    <Control xsi:type="Button" id="PG.RunCommand.AA">
-                                        <Label resid="PG.RunCommand.Label" />
-                                        <Supertip>
-                                            <Title resid="PG.RunCommand.TipTitle" />
-                                            <Description resid="PG.RunSupertip.Desc" />
-                                        </Supertip>
-                                        <Icon>
-                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
-                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
-                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
-                                        </Icon>
-                                        <Action xsi:type="ShowTaskpane">
-                                            <SourceLocation resid="PG.Run.Url" />
-                                            <SupportsPinning>true</SupportsPinning>
-                                        </Action>
-                                    </Control>
-                                </Group>
-                            </OfficeTab>
-                        </ExtensionPoint>
-                        <ExtensionPoint xsi:type="MessageReadCommandSurface">
-                            <OfficeTab id="TabDefault">
-                                <Group id="PG.PlayGroup.MR">
-                                    <Label resid="PG.GroupLabel"/>
-                                    <Control xsi:type="Button" id="PG.RunCommand.MR">
-                                        <Label resid="PG.RunCommand.Label" />
-                                        <Supertip>
-                                            <Title resid="PG.RunCommand.TipTitle" />
-                                            <Description resid="PG.RunSupertip.Desc" />
-                                        </Supertip>
-                                        <Icon>
-                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
-                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
-                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
-                                        </Icon>
-                                        <Action xsi:type="ShowTaskpane">
-                                            <SourceLocation resid="PG.Run.Url" />
-                                            <SupportsPinning>true</SupportsPinning>
-                                        </Action>
-                                    </Control>
-                                </Group>
-                            </OfficeTab>
-                        </ExtensionPoint>
-                        <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
-                            <OfficeTab id="TabDefault">
-                                <Group id="PG.PlayGroup.AO">
-                                    <Label resid="PG.GroupLabel"/>
-                                    <Control xsi:type="Button" id="PG.RunCommand.AO">
-                                        <Label resid="PG.RunCommand.Label" />
-                                        <Supertip>
-                                            <Title resid="PG.RunCommand.TipTitle" />
-                                            <Description resid="PG.RunSupertip.Desc" />
-                                        </Supertip>
-                                        <Icon>
-                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
-                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
-                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
-                                        </Icon>
-                                        <Action xsi:type="ShowTaskpane">
-                                            <SourceLocation resid="PG.Run.Url" />
-                                            <SupportsPinning>true</SupportsPinning>
-                                        </Action>
-                                    </Control>
-                                </Group>
-                            </OfficeTab>
-                        </ExtensionPoint>
-                        <ExtensionPoint xsi:type="MessageComposeCommandSurface">
-                            <OfficeTab id="TabDefault">
-                                <Group id="PG.PlayGroup.MC">
-                                    <Label resid="PG.GroupLabel"/>
-                                    <Control xsi:type="Button" id="PG.RunCommand.MC">
-                                        <Label resid="PG.RunCommand.Label" />
-                                        <Supertip>
-                                            <Title resid="PG.RunCommand.TipTitle" />
-                                            <Description resid="PG.RunSupertip.Desc" />
-                                        </Supertip>
-                                        <Icon>
-                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
-                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
-                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
-                                        </Icon>
-                                        <Action xsi:type="ShowTaskpane">
-                                            <SourceLocation resid="PG.Run.Url" />
-                                            <SupportsPinning>true</SupportsPinning>
-                                        </Action>
-                                    </Control>
-                                </Group>
-                            </OfficeTab>
-                        </ExtensionPoint>
-                        <ExtensionPoint xsi:type="DetectedEntity">
-                            <Label resid="PG.RunCommand.Label" />
-                            <SourceLocation resid="PG.Run.Url" />
-                            <Rule xsi:type="RuleCollection" Mode="Or">
-                                <Rule xsi:type="ItemHasKnownEntity" FilterName="sampleFilterName" RegExFilter="Way" EntityType="Address" Highlight="all" />
-                                <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="sampleRegexName" RegExValue="ScriptLab" PropertyName="BodyAsPlaintext" IgnoreCase="true" Highlight="All" />
-                            </Rule>
-                        </ExtensionPoint>                            
-                    </DesktopFormFactor>
-                </Host>
-            </Hosts>
-            <Resources>
-                <bt:Images>
-                    <bt:Image id="PG.Icon.Run.16" DefaultValue="https://localhost:3000/assets/images/icon-16.png" />
-                    <bt:Image id="PG.Icon.Run.32" DefaultValue="https://localhost:3000/assets/images/icon-32.png" />
-                    <bt:Image id="PG.Icon.Run.80" DefaultValue="https://localhost:3000/assets/images/icon-80.png" />
-                </bt:Images>
-                <bt:Urls>
-                    <bt:Url id="PG.Run.Url" DefaultValue="https://localhost:3000/run.html" />
-                </bt:Urls>
-                <bt:ShortStrings>
-                    <bt:String id="PG.GroupLabel" DefaultValue="[DEV] Script Lab" />
-                    <bt:String id="PG.RunCommand.Label" DefaultValue="Script Lab"></bt:String>
-                    <bt:String id="PG.RunCommand.Title" DefaultValue="Script Lab"></bt:String>
-                    <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Open Script Lab for Outlook"></bt:String>
-                </bt:ShortStrings>
-                <bt:LongStrings>
-                    <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet"></bt:String>
-                </bt:LongStrings>
-            </Resources>
+     <Requirements>
+      <bt:Sets DefaultMinVersion="1.3">
+        <bt:Set Name="Mailbox" />
+      </bt:Sets>
+    </Requirements>
+    <Hosts>
+      <Host xsi:type="MailHost">
+        <DesktopFormFactor>
+	<SupportsSharedFolders>true</SupportsSharedFolders>
+          <FunctionFile resid="PG.Functions.Url" />
+          <ExtensionPoint xsi:type="MessageComposeCommandSurface">
+            <OfficeTab id="TabPlaygroundCompose">
+              <Group id="PG.PlayGroup.Compose">
+                <Label resid="PG.GroupLabel" />
+                <Control xsi:type="Button" id="PG.CodeCommand.Compose">
+                  <Label resid="PG.CodeCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.CodeCommand.TipTitle" />
+                    <Description resid="PG.CodeSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Code.16" />
+                    <bt:Image size="32" resid="PG.Icon.Code.32" />
+                    <bt:Image size="80" resid="PG.Icon.Code.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchCode</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.RunCommand.Compose">
+                  <Label resid="PG.RunCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.RunCommand.TipTitle" />
+                    <Description resid="PG.RunSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Run.16" />
+                    <bt:Image size="32" resid="PG.Icon.Run.32" />
+                    <bt:Image size="80" resid="PG.Icon.Run.80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="PG.Run.Url" />
+                    <SupportsPinning>true</SupportsPinning>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.TutorialCommand.Compose">
+                  <Label resid="PG.TutorialCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.TutorialCommand.TipTitle" />
+                    <Description resid="PG.TutorialCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
+                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
+                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchTutorial</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.HelpCommand.Compose">
+                  <Label resid="PG.HelpCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.HelpCommand.TipTitle" />
+                    <Description resid="PG.HelpCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Help.16" />
+                    <bt:Image size="32" resid="PG.Icon.Help.32" />
+                    <bt:Image size="80" resid="PG.Icon.Help.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchHelp</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.ApiDocsCommand.Compose">
+                  <Label resid="PG.ApiDocsCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.ApiDocsCommand.TipTitle" />
+                    <Description resid="PG.ApiDocsCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
+                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
+                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchApiDocs</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.AskCommand.Compose">
+                  <Label resid="PG.AskCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.AskCommand.TipTitle" />
+                    <Description resid="PG.AskCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
+                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
+                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchAsk</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="MessageReadCommandSurface">
+            <OfficeTab id="TabPlaygroundRead">
+              <Group id="PG.PlayGroup.Read">
+                <Label resid="PG.GroupLabel" />
+                <Control xsi:type="Button" id="PG.CodeCommand.Read">
+                  <Label resid="PG.CodeCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.CodeCommand.TipTitle" />
+                    <Description resid="PG.CodeSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Code.16" />
+                    <bt:Image size="32" resid="PG.Icon.Code.32" />
+                    <bt:Image size="80" resid="PG.Icon.Code.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchCode</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.RunCommand.Read">
+                  <Label resid="PG.RunCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.RunCommand.TipTitle" />
+                    <Description resid="PG.RunSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Run.16" />
+                    <bt:Image size="32" resid="PG.Icon.Run.32" />
+                    <bt:Image size="80" resid="PG.Icon.Run.80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="PG.Run.Url" />
+                    <SupportsPinning>true</SupportsPinning>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.TutorialCommand.Read">
+                  <Label resid="PG.TutorialCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.TutorialCommand.TipTitle" />
+                    <Description resid="PG.TutorialCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
+                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
+                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchTutorial</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.HelpCommand.Read">
+                  <Label resid="PG.HelpCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.HelpCommand.TipTitle" />
+                    <Description resid="PG.HelpCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Help.16" />
+                    <bt:Image size="32" resid="PG.Icon.Help.32" />
+                    <bt:Image size="80" resid="PG.Icon.Help.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchHelp</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.ApiDocsCommand.Read">
+                  <Label resid="PG.ApiDocsCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.ApiDocsCommand.TipTitle" />
+                    <Description resid="PG.ApiDocsCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
+                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
+                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchApiDocs</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.AskCommand.Read">
+                  <Label resid="PG.AskCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.AskCommand.TipTitle" />
+                    <Description resid="PG.AskCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
+                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
+                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchAsk</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
+            <OfficeTab id="TabPlaygroundAppointmentAttendee">
+              <Group id="PG.PlayGroup.AppointmentAttendee">
+                <Label resid="PG.GroupLabel" />
+                <Control xsi:type="Button" id="PG.CodeCommand.AppointmentAttendee">
+                  <Label resid="PG.CodeCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.CodeCommand.TipTitle" />
+                    <Description resid="PG.CodeSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Code.16" />
+                    <bt:Image size="32" resid="PG.Icon.Code.32" />
+                    <bt:Image size="80" resid="PG.Icon.Code.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchCode</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.RunCommand.AppointmentAttendee">
+                  <Label resid="PG.RunCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.RunCommand.TipTitle" />
+                    <Description resid="PG.RunSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Run.16" />
+                    <bt:Image size="32" resid="PG.Icon.Run.32" />
+                    <bt:Image size="80" resid="PG.Icon.Run.80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="PG.Run.Url" />
+                    <SupportsPinning>true</SupportsPinning>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentAttendee">
+                  <Label resid="PG.TutorialCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.TutorialCommand.TipTitle" />
+                    <Description resid="PG.TutorialCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
+                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
+                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchTutorial</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.HelpCommand.AppointmentAttendee">
+                  <Label resid="PG.HelpCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.HelpCommand.TipTitle" />
+                    <Description resid="PG.HelpCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Help.16" />
+                    <bt:Image size="32" resid="PG.Icon.Help.32" />
+                    <bt:Image size="80" resid="PG.Icon.Help.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchHelp</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.ApiDocsCommand.AppointmentAttendee">
+                  <Label resid="PG.ApiDocsCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.ApiDocsCommand.TipTitle" />
+                    <Description resid="PG.ApiDocsCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
+                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
+                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchApiDocs</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.AskCommand.AppointmentAttendee">
+                  <Label resid="PG.AskCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.AskCommand.TipTitle" />
+                    <Description resid="PG.AskCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
+                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
+                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchAsk</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+             </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+            <OfficeTab id="TabPlaygroundAppointmentOrganizer">
+              <Group id="PG.PlayGroup.AppointmentOrganizer">
+                <Label resid="PG.GroupLabel" />
+                <Control xsi:type="Button" id="PG.CodeCommand.AppointmentOrganizer">
+                  <Label resid="PG.CodeCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.CodeCommand.TipTitle" />
+                    <Description resid="PG.CodeSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Code.16" />
+                    <bt:Image size="32" resid="PG.Icon.Code.32" />
+                    <bt:Image size="80" resid="PG.Icon.Code.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchCode</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.RunCommand.AppointmentOrganizer">
+                  <Label resid="PG.RunCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.RunCommand.TipTitle" />
+                    <Description resid="PG.RunSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Run.16" />
+                    <bt:Image size="32" resid="PG.Icon.Run.32" />
+                    <bt:Image size="80" resid="PG.Icon.Run.80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="PG.Run.Url" />
+                    <SupportsPinning>true</SupportsPinning>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentOrganizer">
+                  <Label resid="PG.TutorialCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.TutorialCommand.TipTitle" />
+                    <Description resid="PG.TutorialCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
+                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
+                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchTutorial</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.HelpCommand.AppointmentOrganizer">
+                  <Label resid="PG.HelpCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.HelpCommand.TipTitle" />
+                    <Description resid="PG.HelpCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Help.16" />
+                    <bt:Image size="32" resid="PG.Icon.Help.32" />
+                    <bt:Image size="80" resid="PG.Icon.Help.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchHelp</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.ApiDocsCommand.AppointmentOrganizer">
+                  <Label resid="PG.ApiDocsCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.ApiDocsCommand.TipTitle" />
+                    <Description resid="PG.ApiDocsCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
+                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
+                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchApiDocs</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.AskCommand.AppointmentOrganizer">
+                  <Label resid="PG.AskCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.AskCommand.TipTitle" />
+                    <Description resid="PG.AskCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
+                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
+                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchAsk</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+    </Hosts>
+    <Resources>
+      <bt:Images>
+        <bt:Image id="PG.Icon.16" DefaultValue="https://localhost:3000/assets/images/icon-16.png" />
+        <bt:Image id="PG.Icon.32" DefaultValue="https://localhost:3000/assets/images/icon-32.png" />
+        <bt:Image id="PG.Icon.80" DefaultValue="https://localhost:3000/assets/images/icon-80.png" />
+        <bt:Image id="PG.Icon.Code.16" DefaultValue="https://localhost:3000/assets/images/code-16.png" />
+        <bt:Image id="PG.Icon.Code.32" DefaultValue="https://localhost:3000/assets/images/code-32.png" />
+        <bt:Image id="PG.Icon.Code.80" DefaultValue="https://localhost:3000/assets/images/code-80.png" />
+        <bt:Image id="PG.Icon.Run.16" DefaultValue="https://localhost:3000/assets/images/run-16.png" />
+        <bt:Image id="PG.Icon.Run.32" DefaultValue="https://localhost:3000/assets/images/run-32.png" />
+        <bt:Image id="PG.Icon.Run.80" DefaultValue="https://localhost:3000/assets/images/run-80.png" />
+        <bt:Image id="PG.Icon.Tutorial.16" DefaultValue="https://localhost:3000/assets/images/tutorial-16.png" />
+        <bt:Image id="PG.Icon.Tutorial.32" DefaultValue="https://localhost:3000/assets/images/tutorial-32.png" />
+        <bt:Image id="PG.Icon.Tutorial.80" DefaultValue="https://localhost:3000/assets/images/tutorial-80.png" />
+        <bt:Image id="PG.Icon.Help.16" DefaultValue="https://localhost:3000/assets/images/help-16.png" />
+        <bt:Image id="PG.Icon.Help.32" DefaultValue="https://localhost:3000/assets/images/help-32.png" />
+        <bt:Image id="PG.Icon.Help.80" DefaultValue="https://localhost:3000/assets/images/help-80.png" />
+        <bt:Image id="PG.Icon.ApiDocs.16" DefaultValue="https://localhost:3000/assets/images/docs-16.png" />
+        <bt:Image id="PG.Icon.ApiDocs.32" DefaultValue="https://localhost:3000/assets/images/docs-32.png" />
+        <bt:Image id="PG.Icon.ApiDocs.80" DefaultValue="https://localhost:3000/assets/images/docs-80.png" />
+        <bt:Image id="PG.Icon.Ask.16" DefaultValue="https://localhost:3000/assets/images/ask-16.png" />
+        <bt:Image id="PG.Icon.Ask.32" DefaultValue="https://localhost:3000/assets/images/ask-32.png" />
+        <bt:Image id="PG.Icon.Ask.80" DefaultValue="https://localhost:3000/assets/images/ask-80.png" />
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="PG.Code.Url" DefaultValue="https://localhost:3000?commands=1" />
+        <bt:Url id="PG.Run.Url" DefaultValue="https://localhost:3000/run.html" />
+        <bt:Url id="PG.Functions.Url" DefaultValue="https://localhost:3000/functions.html" />
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="PG.TabLabel" DefaultValue="Script Lab" />
+        <bt:String id="PG.GroupLabel" DefaultValue="Script Lab" />
+        <bt:String id="PG.AboutGroupLabel" DefaultValue="About Script Lab">
+          <bt:Override Locale="de-de" Value="Über Script Lab" />
+          <bt:Override Locale="es-es" Value="Acerca de Script Lab" />
+          <bt:Override Locale="zh-cn" Value="关于Script Lab" />
+        </bt:String>
+        <bt:String id="PG.ApiGroupLabel" DefaultValue="About the APIs">
+          <bt:Override Locale="de-de" Value="Über die APIs" />
+          <bt:Override Locale="es-es" Value="Acerca de las APIs" />
+          <bt:Override Locale="zh-cn" Value="关于APIs" />
+        </bt:String>
+        <bt:String id="PG.CodeCommand.Label" DefaultValue="Code" />
+        <bt:String id="PG.CodeCommand.Title" DefaultValue="Code" />
+        <bt:String id="PG.CodeCommand.TipTitle" DefaultValue="Create or edit code snippets">
+          <bt:Override Locale="de-de" Value="Erstellen oder Editieren von Code-Schnipseln" />
+          <bt:Override Locale="es-es" Value="Crea o edita fragmentos de código" />
+          <bt:Override Locale="zh-cn" Value="创建或编辑代码段" />
+        </bt:String>
+        <bt:String id="PG.RunCommand.Label" DefaultValue="Run">
+          <bt:Override Locale="de-de" Value="Ausführen" />
+          <bt:Override Locale="es-es" Value="Ejecutar" />
+          <bt:Override Locale="zh-cn" Value="运行" />
+        </bt:String>
+        <bt:String id="PG.RunCommand.Title" DefaultValue="Run">
+          <bt:Override Locale="de-de" Value="Ausführen" />
+          <bt:Override Locale="es-es" Value="Ejecutar" />
+          <bt:Override Locale="zh-cn" Value="运行" />
+        </bt:String>
+        <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Run the code snippet">
+          <bt:Override Locale="de-de" Value="Code-Schnipsel ausführen" />
+          <bt:Override Locale="es-es" Value="Ejecuta el fragmento de código" />
+          <bt:Override Locale="zh-cn" Value="运行代码片段" />
+        </bt:String>
+        <bt:String id="PG.TutorialCommand.Label" DefaultValue="Tutorial" />
+        <bt:String id="PG.TutorialCommand.TipTitle" DefaultValue="Script Lab tutorial">
+          <bt:Override Locale="de-de" Value="Tutorial zu Script Lab" />
+          <bt:Override Locale="es-es" Value="Tutorial de Script Lab" />
+          <bt:Override Locale="zh-cn" Value="Script Lab教程" />
+        </bt:String>
+        <bt:String id="PG.HelpCommand.Label" DefaultValue="Help">
+          <bt:Override Locale="de-de" Value="Hilfe" />
+          <bt:Override Locale="es-es" Value="Ayuda" />
+          <bt:Override Locale="zh-cn" Value="帮助" />
+        </bt:String>
+        <bt:String id="PG.HelpCommand.TipTitle" DefaultValue="Help for Script Lab">
+          <bt:Override Locale="de-de" Value="Hilfe zu Script Lab" />
+          <bt:Override Locale="es-es" Value="Ayuda de Script Lab" />
+          <bt:Override Locale="zh-cn" Value="帮助Script Lab" />
+        </bt:String>
+        <bt:String id="PG.ApiDocsCommand.Label" DefaultValue="Reference Docs">
+          <bt:Override Locale="de-de" Value="Dokumentation" />
+          <bt:Override Locale="es-es" Value="Documentación" />
+          <bt:Override Locale="zh-cn" Value="参考文档" />
+        </bt:String>
+        <bt:String id="PG.ApiDocsCommand.TipTitle" DefaultValue="API Reference Documentation">
+          <bt:Override Locale="de-de" Value="API-Dokumentation" />
+          <bt:Override Locale="es-es" Value="Documentación de la API" />
+          <bt:Override Locale="zh-cn" Value="API参考文案" />
+        </bt:String>
+        <bt:String id="PG.AskCommand.Label" DefaultValue="Ask the Community">
+          <bt:Override Locale="de-de" Value="Community" />
+          <bt:Override Locale="es-es" Value="Comunidad" />
+          <bt:Override Locale="zh-cn" Value="问社区" />
+        </bt:String>
+        <bt:String id="PG.AskCommand.TipTitle" DefaultValue="Get API help from the community">
+          <bt:Override Locale="de-de" Value="Unterstützung durch die Community" />
+          <bt:Override Locale="es-es" Value="Obtén ayuda de nuestra comunidad" />
+          <bt:Override Locale="zh-cn" Value="从社区获取API帮助" />
+        </bt:String>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="PG.CodeSupertip.Desc" DefaultValue="Opens the Script Lab code editor">
+          <bt:Override Locale="de-de" Value="Den Script Lab Code-Editor aufrufen." />
+          <bt:Override Locale="es-es" Value="Abre el editor de código de Script Lab." />
+          <bt:Override Locale="zh-cn" Value="打开Script Lab代码编辑器" />
+        </bt:String>
+        <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet">
+          <bt:Override Locale="de-de" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen." />
+          <bt:Override Locale="es-es" Value="Abre el panel que ejecuta el fragmento de código actual." />
+          <bt:Override Locale="zh-cn" Value="打开运行当前代码段的任务窗格" />
+        </bt:String>
+        <bt:String id="PG.TutorialCommand.Desc" DefaultValue="Launches a quick Script Lab tutorial">
+          <bt:Override Locale="de-de" Value="Ein Tutorial zu Script Lab aufrufen." />
+          <bt:Override Locale="es-es" Value="Abre un breve tutorial de Script Lab." />
+          <bt:Override Locale="zh-cn" Value="快速启动Script Lab教程" />
+        </bt:String>
+        <bt:String id="PG.HelpCommand.Desc" DefaultValue="Launches documentation on using Script Lab">
+          <bt:Override Locale="de-de" Value="Die Dokumentation zu Script Lab aufrufen." />
+          <bt:Override Locale="es-es" Value="Abre la documentación acerca del uso de Script Lab." />
+          <bt:Override Locale="zh-cn" Value="使用Script Lab发布文档" />
+        </bt:String>
+        <bt:String id="PG.ApiDocsCommand.Desc" DefaultValue="Opens the API documentation for the Office application that you are running">
+          <bt:Override Locale="de-de" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen." />
+          <bt:Override Locale="es-es" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo." />
+          <bt:Override Locale="zh-cn" Value="打开正在运行的Office应用程序的API文档" />
+        </bt:String>
+        <bt:String id="PG.AskCommand.Desc" DefaultValue="Launches a community forum for questions about the Office JavaScript APIs">
+          <bt:Override Locale="de-de" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen." />
+          <bt:Override Locale="es-es" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office." />
+          <bt:Override Locale="zh-cn" Value="启动一个社区论坛，讨论有关Office JavaScript API的问题" />
+        </bt:String>
+        <bt:String id="PG.Description" DefaultValue="Code, run, and share your Add-in snippets directly from Office.">
+          <bt:Override Locale="de-de" Value="JavaScript-Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen." />
+          <bt:Override Locale="es-es" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office." />
+          <bt:Override Locale="zh-cn" Value="直接从Office中编码、运行和共享附加代码片段。" />
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
         </VersionOverrides>
     </VersionOverrides>
 </OfficeApp>

--- a/manifests/script-lab-react-localhost.outlook.xml
+++ b/manifests/script-lab-react-localhost.outlook.xml
@@ -7,7 +7,7 @@
     <Version>2.0.0.0</Version>
     <ProviderName>Microsoft</ProviderName>
     <DefaultLocale>en-US</DefaultLocale>
-    <DisplayName DefaultValue="[Dev] Script Lab for Outlook />
+    <DisplayName DefaultValue="[Dev] Script Lab for Outlook" />
     <Description DefaultValue="Create, run, and share your Office Add-in code snippets from within Outlook."></Description>
     <IconUrl DefaultValue="https://localhost:3000/assets/images/icon-64.png" />
     <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/images/icon-64.png" />

--- a/manifests/script-lab-react-localhost.outlook.xml
+++ b/manifests/script-lab-react-localhost.outlook.xml
@@ -7,7 +7,7 @@
     <Version>2.0.0.0</Version>
     <ProviderName>Microsoft</ProviderName>
     <DefaultLocale>en-US</DefaultLocale>
-    <DisplayName DefaultValue="[Dev] Script Lab for Outlook" />
+    <DisplayName DefaultValue="[Dev] Script Lab for Outlook />
     <Description DefaultValue="Create, run, and share your Office Add-in code snippets from within Outlook."></Description>
     <IconUrl DefaultValue="https://localhost:3000/assets/images/icon-64.png" />
     <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/images/icon-64.png" />
@@ -183,578 +183,137 @@
         </Resources>
         <!-- Version Overrides 1.1-->
         <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
-     <Requirements>
-      <bt:Sets DefaultMinVersion="1.3">
-        <bt:Set Name="Mailbox" />
-      </bt:Sets>
-    </Requirements>
-    <Hosts>
-      <Host xsi:type="MailHost">
-        <DesktopFormFactor>
-	        <SupportsSharedFolders>true</SupportsSharedFolders>
-          <FunctionFile resid="PG.Functions.Url" />
-          <ExtensionPoint xsi:type="MessageComposeCommandSurface">
-            <CustomTab id="TabPlaygroundCompose">
-              <Group id="PG.PlayGroup.Compose">
-                <Label resid="PG.GroupLabel" />
-                <Control xsi:type="Button" id="PG.CodeCommand.Compose">
-                  <Label resid="PG.CodeCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.CodeCommand.TipTitle" />
-                    <Description resid="PG.CodeSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Code.16" />
-                    <bt:Image size="32" resid="PG.Icon.Code.32" />
-                    <bt:Image size="80" resid="PG.Icon.Code.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchCode</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.RunCommand.Compose">
-                  <Label resid="PG.RunCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.RunCommand.TipTitle" />
-                    <Description resid="PG.RunSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Run.16" />
-                    <bt:Image size="32" resid="PG.Icon.Run.32" />
-                    <bt:Image size="80" resid="PG.Icon.Run.80" />
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="PG.Run.Url" />
-                    <SupportsPinning>true</SupportsPinning>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.AboutGroup.Compose">
-                <Label resid="PG.AboutGroupLabel" />
-                <Control xsi:type="Button" id="PG.TutorialCommand.Compose">
-                  <Label resid="PG.TutorialCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.TutorialCommand.TipTitle" />
-                    <Description resid="PG.TutorialCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
-                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
-                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchTutorial</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.HelpCommand.Compose">
-                  <Label resid="PG.HelpCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.HelpCommand.TipTitle" />
-                    <Description resid="PG.HelpCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Help.16" />
-                    <bt:Image size="32" resid="PG.Icon.Help.32" />
-                    <bt:Image size="80" resid="PG.Icon.Help.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchHelp</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.ApiGroup.Compose">
-                <Label resid="PG.ApiGroupLabel" />
-                <Control xsi:type="Button" id="PG.ApiDocsCommand.Compose">
-                  <Label resid="PG.ApiDocsCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.ApiDocsCommand.TipTitle" />
-                    <Description resid="PG.ApiDocsCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
-                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
-                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchApiDocs</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.AskCommand.Compose">
-                  <Label resid="PG.AskCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.AskCommand.TipTitle" />
-                    <Description resid="PG.AskCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
-                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
-                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchAsk</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Label resid="PG.TabLabel" />
-            </CustomTab>
-          </ExtensionPoint>
-          <ExtensionPoint xsi:type="MessageReadCommandSurface">
-            <CustomTab id="TabPlaygroundRead">
-              <Group id="PG.PlayGroup.Read">
-                <Label resid="PG.GroupLabel" />
-                <Control xsi:type="Button" id="PG.CodeCommand.Read">
-                  <Label resid="PG.CodeCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.CodeCommand.TipTitle" />
-                    <Description resid="PG.CodeSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Code.16" />
-                    <bt:Image size="32" resid="PG.Icon.Code.32" />
-                    <bt:Image size="80" resid="PG.Icon.Code.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchCode</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.RunCommand.Read">
-                  <Label resid="PG.RunCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.RunCommand.TipTitle" />
-                    <Description resid="PG.RunSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Run.16" />
-                    <bt:Image size="32" resid="PG.Icon.Run.32" />
-                    <bt:Image size="80" resid="PG.Icon.Run.80" />
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="PG.Run.Url" />
-                    <SupportsPinning>true</SupportsPinning>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.AboutGroup.Read">
-                <Label resid="PG.AboutGroupLabel" />
-                <Control xsi:type="Button" id="PG.TutorialCommand.Read">
-                  <Label resid="PG.TutorialCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.TutorialCommand.TipTitle" />
-                    <Description resid="PG.TutorialCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
-                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
-                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchTutorial</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.HelpCommand.Read">
-                  <Label resid="PG.HelpCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.HelpCommand.TipTitle" />
-                    <Description resid="PG.HelpCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Help.16" />
-                    <bt:Image size="32" resid="PG.Icon.Help.32" />
-                    <bt:Image size="80" resid="PG.Icon.Help.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchHelp</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.ApiGroup.Read">
-                <Label resid="PG.ApiGroupLabel" />
-                <Control xsi:type="Button" id="PG.ApiDocsCommand.Read">
-                  <Label resid="PG.ApiDocsCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.ApiDocsCommand.TipTitle" />
-                    <Description resid="PG.ApiDocsCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
-                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
-                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchApiDocs</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.AskCommand.Read">
-                  <Label resid="PG.AskCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.AskCommand.TipTitle" />
-                    <Description resid="PG.AskCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
-                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
-                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchAsk</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Label resid="PG.TabLabel" />
-            </CustomTab>
-          </ExtensionPoint>
-          <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
-            <CustomTab id="TabPlaygroundAppointmentAttendee">
-              <Group id="PG.PlayGroup.AppointmentAttendee">
-                <Label resid="PG.GroupLabel" />
-                <Control xsi:type="Button" id="PG.CodeCommand.AppointmentAttendee">
-                  <Label resid="PG.CodeCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.CodeCommand.TipTitle" />
-                    <Description resid="PG.CodeSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Code.16" />
-                    <bt:Image size="32" resid="PG.Icon.Code.32" />
-                    <bt:Image size="80" resid="PG.Icon.Code.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchCode</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.RunCommand.AppointmentAttendee">
-                  <Label resid="PG.RunCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.RunCommand.TipTitle" />
-                    <Description resid="PG.RunSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Run.16" />
-                    <bt:Image size="32" resid="PG.Icon.Run.32" />
-                    <bt:Image size="80" resid="PG.Icon.Run.80" />
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="PG.Run.Url" />
-                    <SupportsPinning>true</SupportsPinning>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.AboutGroup.AppointmentAttendee">
-                <Label resid="PG.AboutGroupLabel" />
-                <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentAttendee">
-                  <Label resid="PG.TutorialCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.TutorialCommand.TipTitle" />
-                    <Description resid="PG.TutorialCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
-                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
-                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchTutorial</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.HelpCommand.AppointmentAttendee">
-                  <Label resid="PG.HelpCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.HelpCommand.TipTitle" />
-                    <Description resid="PG.HelpCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Help.16" />
-                    <bt:Image size="32" resid="PG.Icon.Help.32" />
-                    <bt:Image size="80" resid="PG.Icon.Help.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchHelp</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.ApiGroup.AppointmentAttendee">
-                <Label resid="PG.ApiGroupLabel" />
-                <Control xsi:type="Button" id="PG.ApiDocsCommand.AppointmentAttendee">
-                  <Label resid="PG.ApiDocsCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.ApiDocsCommand.TipTitle" />
-                    <Description resid="PG.ApiDocsCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
-                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
-                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchApiDocs</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.AskCommand.AppointmentAttendee">
-                  <Label resid="PG.AskCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.AskCommand.TipTitle" />
-                    <Description resid="PG.AskCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
-                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
-                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchAsk</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Label resid="PG.TabLabel" />
-            </CustomTab>
-          </ExtensionPoint>
-          <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
-            <CustomTab id="TabPlaygroundAppointmentOrganizer">
-              <Group id="PG.PlayGroup.AppointmentOrganizer">
-                <Label resid="PG.GroupLabel" />
-                <Control xsi:type="Button" id="PG.CodeCommand.AppointmentOrganizer">
-                  <Label resid="PG.CodeCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.CodeCommand.TipTitle" />
-                    <Description resid="PG.CodeSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Code.16" />
-                    <bt:Image size="32" resid="PG.Icon.Code.32" />
-                    <bt:Image size="80" resid="PG.Icon.Code.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchCode</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.RunCommand.AppointmentOrganizer">
-                  <Label resid="PG.RunCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.RunCommand.TipTitle" />
-                    <Description resid="PG.RunSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Run.16" />
-                    <bt:Image size="32" resid="PG.Icon.Run.32" />
-                    <bt:Image size="80" resid="PG.Icon.Run.80" />
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="PG.Run.Url" />
-                    <SupportsPinning>true</SupportsPinning>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.AboutGroup.AppointmentOrganizer">
-                <Label resid="PG.AboutGroupLabel" />
-                <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentOrganizer">
-                  <Label resid="PG.TutorialCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.TutorialCommand.TipTitle" />
-                    <Description resid="PG.TutorialCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
-                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
-                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchTutorial</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.HelpCommand.AppointmentOrganizer">
-                  <Label resid="PG.HelpCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.HelpCommand.TipTitle" />
-                    <Description resid="PG.HelpCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Help.16" />
-                    <bt:Image size="32" resid="PG.Icon.Help.32" />
-                    <bt:Image size="80" resid="PG.Icon.Help.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchHelp</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.ApiGroup.AppointmentOrganizer">
-                <Label resid="PG.ApiGroupLabel" />
-                <Control xsi:type="Button" id="PG.ApiDocsCommand.AppointmentOrganizer">
-                  <Label resid="PG.ApiDocsCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.ApiDocsCommand.TipTitle" />
-                    <Description resid="PG.ApiDocsCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
-                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
-                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchApiDocs</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.AskCommand.AppointmentOrganizer">
-                  <Label resid="PG.AskCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.AskCommand.TipTitle" />
-                    <Description resid="PG.AskCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
-                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
-                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchAsk</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Label resid="PG.TabLabel" />
-            </CustomTab>
-          </ExtensionPoint>
-        </DesktopFormFactor>
-      </Host>
-    </Hosts>
-    <Resources>
-      <bt:Images>
-        <bt:Image id="PG.Icon.16" DefaultValue="https://localhost:3000/assets/images/icon-16.png" />
-        <bt:Image id="PG.Icon.32" DefaultValue="https://localhost:3000/assets/images/icon-32.png" />
-        <bt:Image id="PG.Icon.80" DefaultValue="https://localhost:3000/assets/images/icon-80.png" />
-        <bt:Image id="PG.Icon.Code.16" DefaultValue="https://localhost:3000/assets/images/code-16.png" />
-        <bt:Image id="PG.Icon.Code.32" DefaultValue="https://localhost:3000/assets/images/code-32.png" />
-        <bt:Image id="PG.Icon.Code.80" DefaultValue="https://localhost:3000/assets/images/code-80.png" />
-        <bt:Image id="PG.Icon.Run.16" DefaultValue="https://localhost:3000/assets/images/run-16.png" />
-        <bt:Image id="PG.Icon.Run.32" DefaultValue="https://localhost:3000/assets/images/run-32.png" />
-        <bt:Image id="PG.Icon.Run.80" DefaultValue="https://localhost:3000/assets/images/run-80.png" />
-        <bt:Image id="PG.Icon.Tutorial.16" DefaultValue="https://localhost:3000/assets/images/tutorial-16.png" />
-        <bt:Image id="PG.Icon.Tutorial.32" DefaultValue="https://localhost:3000/assets/images/tutorial-32.png" />
-        <bt:Image id="PG.Icon.Tutorial.80" DefaultValue="https://localhost:3000/assets/images/tutorial-80.png" />
-        <bt:Image id="PG.Icon.Help.16" DefaultValue="https://localhost:3000/assets/images/help-16.png" />
-        <bt:Image id="PG.Icon.Help.32" DefaultValue="https://localhost:3000/assets/images/help-32.png" />
-        <bt:Image id="PG.Icon.Help.80" DefaultValue="https://localhost:3000/assets/images/help-80.png" />
-        <bt:Image id="PG.Icon.ApiDocs.16" DefaultValue="https://localhost:3000/assets/images/docs-16.png" />
-        <bt:Image id="PG.Icon.ApiDocs.32" DefaultValue="https://localhost:3000/assets/images/docs-32.png" />
-        <bt:Image id="PG.Icon.ApiDocs.80" DefaultValue="https://localhost:3000/assets/images/docs-80.png" />
-        <bt:Image id="PG.Icon.Ask.16" DefaultValue="https://localhost:3000/assets/images/ask-16.png" />
-        <bt:Image id="PG.Icon.Ask.32" DefaultValue="https://localhost:3000/assets/images/ask-32.png" />
-        <bt:Image id="PG.Icon.Ask.80" DefaultValue="https://localhost:3000/assets/images/ask-80.png" />
-      </bt:Images>
-      <bt:Urls>
-        <bt:Url id="PG.Code.Url" DefaultValue="https://localhost:3000?commands=1" />
-        <bt:Url id="PG.Run.Url" DefaultValue="https://localhost:3000/run.html" />
-        <bt:Url id="PG.Functions.Url" DefaultValue="https://localhost:3000/functions.html" />
-      </bt:Urls>
-      <bt:ShortStrings>
-        <bt:String id="PG.TabLabel" DefaultValue="Script Lab" />
-        <bt:String id="PG.GroupLabel" DefaultValue="Script" />
-        <bt:String id="PG.AboutGroupLabel" DefaultValue="About Script Lab">
-          <bt:Override Locale="de-de" Value="Über Script Lab" />
-          <bt:Override Locale="es-es" Value="Acerca de Script Lab" />
-          <bt:Override Locale="zh-cn" Value="关于Script Lab" />
-        </bt:String>
-        <bt:String id="PG.ApiGroupLabel" DefaultValue="About the APIs">
-          <bt:Override Locale="de-de" Value="Über die APIs" />
-          <bt:Override Locale="es-es" Value="Acerca de las APIs" />
-          <bt:Override Locale="zh-cn" Value="关于APIs" />
-        </bt:String>
-        <bt:String id="PG.CodeCommand.Label" DefaultValue="Code" />
-        <bt:String id="PG.CodeCommand.Title" DefaultValue="Code" />
-        <bt:String id="PG.CodeCommand.TipTitle" DefaultValue="Create or edit code snippets">
-          <bt:Override Locale="de-de" Value="Erstellen oder Editieren von Code-Schnipseln" />
-          <bt:Override Locale="es-es" Value="Crea o edita fragmentos de código" />
-          <bt:Override Locale="zh-cn" Value="创建或编辑代码段" />
-        </bt:String>
-        <bt:String id="PG.RunCommand.Label" DefaultValue="Run">
-          <bt:Override Locale="de-de" Value="Ausführen" />
-          <bt:Override Locale="es-es" Value="Ejecutar" />
-          <bt:Override Locale="zh-cn" Value="运行" />
-        </bt:String>
-        <bt:String id="PG.RunCommand.Title" DefaultValue="Run">
-          <bt:Override Locale="de-de" Value="Ausführen" />
-          <bt:Override Locale="es-es" Value="Ejecutar" />
-          <bt:Override Locale="zh-cn" Value="运行" />
-        </bt:String>
-        <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Run the code snippet">
-          <bt:Override Locale="de-de" Value="Code-Schnipsel ausführen" />
-          <bt:Override Locale="es-es" Value="Ejecuta el fragmento de código" />
-          <bt:Override Locale="zh-cn" Value="运行代码片段" />
-        </bt:String>
-        <bt:String id="PG.TutorialCommand.Label" DefaultValue="Tutorial" />
-        <bt:String id="PG.TutorialCommand.TipTitle" DefaultValue="Script Lab tutorial">
-          <bt:Override Locale="de-de" Value="Tutorial zu Script Lab" />
-          <bt:Override Locale="es-es" Value="Tutorial de Script Lab" />
-          <bt:Override Locale="zh-cn" Value="Script Lab教程" />
-        </bt:String>
-        <bt:String id="PG.HelpCommand.Label" DefaultValue="Help">
-          <bt:Override Locale="de-de" Value="Hilfe" />
-          <bt:Override Locale="es-es" Value="Ayuda" />
-          <bt:Override Locale="zh-cn" Value="帮助" />
-        </bt:String>
-        <bt:String id="PG.HelpCommand.TipTitle" DefaultValue="Help for Script Lab">
-          <bt:Override Locale="de-de" Value="Hilfe zu Script Lab" />
-          <bt:Override Locale="es-es" Value="Ayuda de Script Lab" />
-          <bt:Override Locale="zh-cn" Value="帮助Script Lab" />
-        </bt:String>
-        <bt:String id="PG.ApiDocsCommand.Label" DefaultValue="Reference Docs">
-          <bt:Override Locale="de-de" Value="Dokumentation" />
-          <bt:Override Locale="es-es" Value="Documentación" />
-          <bt:Override Locale="zh-cn" Value="参考文档" />
-        </bt:String>
-        <bt:String id="PG.ApiDocsCommand.TipTitle" DefaultValue="API Reference Documentation">
-          <bt:Override Locale="de-de" Value="API-Dokumentation" />
-          <bt:Override Locale="es-es" Value="Documentación de la API" />
-          <bt:Override Locale="zh-cn" Value="API参考文案" />
-        </bt:String>
-        <bt:String id="PG.AskCommand.Label" DefaultValue="Ask the Community">
-          <bt:Override Locale="de-de" Value="Community" />
-          <bt:Override Locale="es-es" Value="Comunidad" />
-          <bt:Override Locale="zh-cn" Value="问社区" />
-        </bt:String>
-        <bt:String id="PG.AskCommand.TipTitle" DefaultValue="Get API help from the community">
-          <bt:Override Locale="de-de" Value="Unterstützung durch die Community" />
-          <bt:Override Locale="es-es" Value="Obtén ayuda de nuestra comunidad" />
-          <bt:Override Locale="zh-cn" Value="从社区获取API帮助" />
-        </bt:String>
-      </bt:ShortStrings>
-      <bt:LongStrings>
-        <bt:String id="PG.CodeSupertip.Desc" DefaultValue="Opens the Script Lab code editor">
-          <bt:Override Locale="de-de" Value="Den Script Lab Code-Editor aufrufen." />
-          <bt:Override Locale="es-es" Value="Abre el editor de código de Script Lab." />
-          <bt:Override Locale="zh-cn" Value="打开Script Lab代码编辑器" />
-        </bt:String>
-        <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet">
-          <bt:Override Locale="de-de" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen." />
-          <bt:Override Locale="es-es" Value="Abre el panel que ejecuta el fragmento de código actual." />
-          <bt:Override Locale="zh-cn" Value="打开运行当前代码段的任务窗格" />
-        </bt:String>
-        <bt:String id="PG.TutorialCommand.Desc" DefaultValue="Launches a quick Script Lab tutorial">
-          <bt:Override Locale="de-de" Value="Ein Tutorial zu Script Lab aufrufen." />
-          <bt:Override Locale="es-es" Value="Abre un breve tutorial de Script Lab." />
-          <bt:Override Locale="zh-cn" Value="快速启动Script Lab教程" />
-        </bt:String>
-        <bt:String id="PG.HelpCommand.Desc" DefaultValue="Launches documentation on using Script Lab">
-          <bt:Override Locale="de-de" Value="Die Dokumentation zu Script Lab aufrufen." />
-          <bt:Override Locale="es-es" Value="Abre la documentación acerca del uso de Script Lab." />
-          <bt:Override Locale="zh-cn" Value="使用Script Lab发布文档" />
-        </bt:String>
-        <bt:String id="PG.ApiDocsCommand.Desc" DefaultValue="Opens the API documentation for the Office application that you are running">
-          <bt:Override Locale="de-de" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen." />
-          <bt:Override Locale="es-es" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo." />
-          <bt:Override Locale="zh-cn" Value="打开正在运行的Office应用程序的API文档" />
-        </bt:String>
-        <bt:String id="PG.AskCommand.Desc" DefaultValue="Launches a community forum for questions about the Office JavaScript APIs">
-          <bt:Override Locale="de-de" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen." />
-          <bt:Override Locale="es-es" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office." />
-          <bt:Override Locale="zh-cn" Value="启动一个社区论坛，讨论有关Office JavaScript API的问题" />
-        </bt:String>
-        <bt:String id="PG.Description" DefaultValue="Code, run, and share your Add-in snippets directly from Office.">
-          <bt:Override Locale="de-de" Value="JavaScript-Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen." />
-          <bt:Override Locale="es-es" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office." />
-          <bt:Override Locale="zh-cn" Value="直接从Office中编码、运行和共享附加代码片段。" />
-        </bt:String>
-      </bt:LongStrings>
-    </Resources>
+            <Requirements>
+                <bt:Sets DefaultMinVersion="1.3">
+                    <bt:Set Name="Mailbox"/>
+                </bt:Sets>
+            </Requirements>
+            <Hosts>
+                <Host xsi:type="MailHost">
+                    <DesktopFormFactor>
+                        <SupportsSharedFolders>true</SupportsSharedFolders>
+                        <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
+                            <OfficeTab id="TabDefault">
+                                <Group id="PG.PlayGroup.AA">
+                                    <Label resid="PG.GroupLabel"/>
+                                    <Control xsi:type="Button" id="PG.RunCommand.AA">
+                                        <Label resid="PG.RunCommand.Label" />
+                                        <Supertip>
+                                            <Title resid="PG.RunCommand.TipTitle" />
+                                            <Description resid="PG.RunSupertip.Desc" />
+                                        </Supertip>
+                                        <Icon>
+                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
+                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
+                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
+                                        </Icon>
+                                        <Action xsi:type="ShowTaskpane">
+                                            <SourceLocation resid="PG.Run.Url" />
+                                            <SupportsPinning>true</SupportsPinning>
+                                        </Action>
+                                    </Control>
+                                </Group>
+                            </OfficeTab>
+                        </ExtensionPoint>
+                        <ExtensionPoint xsi:type="MessageReadCommandSurface">
+                            <OfficeTab id="TabDefault">
+                                <Group id="PG.PlayGroup.MR">
+                                    <Label resid="PG.GroupLabel"/>
+                                    <Control xsi:type="Button" id="PG.RunCommand.MR">
+                                        <Label resid="PG.RunCommand.Label" />
+                                        <Supertip>
+                                            <Title resid="PG.RunCommand.TipTitle" />
+                                            <Description resid="PG.RunSupertip.Desc" />
+                                        </Supertip>
+                                        <Icon>
+                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
+                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
+                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
+                                        </Icon>
+                                        <Action xsi:type="ShowTaskpane">
+                                            <SourceLocation resid="PG.Run.Url" />
+                                            <SupportsPinning>true</SupportsPinning>
+                                        </Action>
+                                    </Control>
+                                </Group>
+                            </OfficeTab>
+                        </ExtensionPoint>
+                        <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+                            <OfficeTab id="TabDefault">
+                                <Group id="PG.PlayGroup.AO">
+                                    <Label resid="PG.GroupLabel"/>
+                                    <Control xsi:type="Button" id="PG.RunCommand.AO">
+                                        <Label resid="PG.RunCommand.Label" />
+                                        <Supertip>
+                                            <Title resid="PG.RunCommand.TipTitle" />
+                                            <Description resid="PG.RunSupertip.Desc" />
+                                        </Supertip>
+                                        <Icon>
+                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
+                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
+                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
+                                        </Icon>
+                                        <Action xsi:type="ShowTaskpane">
+                                            <SourceLocation resid="PG.Run.Url" />
+                                            <SupportsPinning>true</SupportsPinning>
+                                        </Action>
+                                    </Control>
+                                </Group>
+                            </OfficeTab>
+                        </ExtensionPoint>
+                        <ExtensionPoint xsi:type="MessageComposeCommandSurface">
+                            <OfficeTab id="TabDefault">
+                                <Group id="PG.PlayGroup.MC">
+                                    <Label resid="PG.GroupLabel"/>
+                                    <Control xsi:type="Button" id="PG.RunCommand.MC">
+                                        <Label resid="PG.RunCommand.Label" />
+                                        <Supertip>
+                                            <Title resid="PG.RunCommand.TipTitle" />
+                                            <Description resid="PG.RunSupertip.Desc" />
+                                        </Supertip>
+                                        <Icon>
+                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
+                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
+                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
+                                        </Icon>
+                                        <Action xsi:type="ShowTaskpane">
+                                            <SourceLocation resid="PG.Run.Url" />
+                                            <SupportsPinning>true</SupportsPinning>
+                                        </Action>
+                                    </Control>
+                                </Group>
+                            </OfficeTab>
+                        </ExtensionPoint>
+                        <ExtensionPoint xsi:type="DetectedEntity">
+                            <Label resid="PG.RunCommand.Label" />
+                            <SourceLocation resid="PG.Run.Url" />
+                            <Rule xsi:type="RuleCollection" Mode="Or">
+                                <Rule xsi:type="ItemHasKnownEntity" FilterName="sampleFilterName" RegExFilter="Way" EntityType="Address" Highlight="all" />
+                                <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="sampleRegexName" RegExValue="ScriptLab" PropertyName="BodyAsPlaintext" IgnoreCase="true" Highlight="All" />
+                            </Rule>
+                        </ExtensionPoint>                            
+                    </DesktopFormFactor>
+                </Host>
+            </Hosts>
+            <Resources>
+                <bt:Images>
+                    <bt:Image id="PG.Icon.Run.16" DefaultValue="https://localhost:3000/assets/images/icon-16.png" />
+                    <bt:Image id="PG.Icon.Run.32" DefaultValue="https://localhost:3000/assets/images/icon-32.png" />
+                    <bt:Image id="PG.Icon.Run.80" DefaultValue="https://localhost:3000/assets/images/icon-80.png" />
+                </bt:Images>
+                <bt:Urls>
+                    <bt:Url id="PG.Run.Url" DefaultValue="https://localhost:3000/run.html" />
+                </bt:Urls>
+                <bt:ShortStrings>
+                    <bt:String id="PG.GroupLabel" DefaultValue="[DEV] Script Lab" />
+                    <bt:String id="PG.RunCommand.Label" DefaultValue="Script Lab"></bt:String>
+                    <bt:String id="PG.RunCommand.Title" DefaultValue="Script Lab"></bt:String>
+                    <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Open Script Lab for Outlook"></bt:String>
+                </bt:ShortStrings>
+                <bt:LongStrings>
+                    <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet"></bt:String>
+                </bt:LongStrings>
+            </Resources>
         </VersionOverrides>
     </VersionOverrides>
 </OfficeApp>

--- a/manifests/script-lab-react-prod.outlook.xml
+++ b/manifests/script-lab-react-prod.outlook.xml
@@ -9,8 +9,8 @@
     <DefaultLocale>en-US</DefaultLocale>
     <DisplayName DefaultValue="Script Lab for Outlook" />
     <Description DefaultValue="Create, run, and share your Office Add-in code snippets from within Outlook."></Description>
-    <IconUrl DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-64.png" />
-    <HighResolutionIconUrl DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-64.png" />
+    <IconUrl DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/icon-64.png" />
+    <HighResolutionIconUrl DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/icon-64.png" />
     <SupportUrl DefaultValue="https://github.com/OfficeDev/script-lab/issues" />
     <AppDomains>
         <AppDomain>https://github.com</AppDomain>
@@ -52,7 +52,7 @@
     <FormSettings>
         <Form xsi:type="ItemRead">
             <DesktopSettings>
-                <SourceLocation DefaultValue="https://script-lab-react-alpha.azurewebsites.net" />
+                <SourceLocation DefaultValue="https://script-lab-react.azurewebsites.net" />
                 <RequestedHeight>450</RequestedHeight>
             </DesktopSettings>
         </Form>
@@ -164,16 +164,16 @@
         </Hosts>
         <Resources>
             <bt:Images>
-                <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/run-16.png" />
-                <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/run-32.png" />
-                <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/run-80.png" />
+                <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/run-16.png" />
+                <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/run-32.png" />
+                <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/run-80.png" />
             </bt:Images>
             <bt:Urls>
-                <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/run.html" />
+                <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab-react.azurewebsites.net/run.html" />
             </bt:Urls>
             <bt:ShortStrings>
 
-                <bt:String id="PG.GroupLabel" DefaultValue="Script Lab [ALPHA]" />
+                <bt:String id="PG.GroupLabel" DefaultValue="Script Lab" />
                 <bt:String id="PG.RunCommand.Label" DefaultValue="Script Lab"></bt:String>
                 <bt:String id="PG.RunCommand.Title" DefaultValue="Script Lab"></bt:String>
                 <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Open Script Lab for Outlook"></bt:String>
@@ -298,15 +298,15 @@
             </Hosts>
             <Resources>
                 <bt:Images>
-                    <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-16.png" />
-                    <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-32.png" />
-                    <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-80.png" />
+                    <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/icon-16.png" />
+                    <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/icon-32.png" />
+                    <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/icon-80.png" />
                 </bt:Images>
                 <bt:Urls>
-                    <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/run.html" />
+                    <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab-react.azurewebsites.net/run.html" />
                 </bt:Urls>
                 <bt:ShortStrings>
-                    <bt:String id="PG.GroupLabel" DefaultValue="Script Lab [ALPHA]" />
+                    <bt:String id="PG.GroupLabel" DefaultValue="Script Lab" />
                     <bt:String id="PG.RunCommand.Label" DefaultValue="Script Lab"></bt:String>
                     <bt:String id="PG.RunCommand.Title" DefaultValue="Script Lab"></bt:String>
                     <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Open Script Lab for Outlook"></bt:String>

--- a/manifests/script-lab-react-prod.outlook.xml
+++ b/manifests/script-lab-react-prod.outlook.xml
@@ -172,7 +172,6 @@
                 <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab-react.azurewebsites.net/run.html" />
             </bt:Urls>
             <bt:ShortStrings>
-
                 <bt:String id="PG.GroupLabel" DefaultValue="Script Lab" />
                 <bt:String id="PG.RunCommand.Label" DefaultValue="Script Lab"></bt:String>
                 <bt:String id="PG.RunCommand.Title" DefaultValue="Script Lab"></bt:String>
@@ -184,137 +183,961 @@
         </Resources>
         <!-- Version Overrides 1.1-->
         <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
-            <Requirements>
-                <bt:Sets DefaultMinVersion="1.3">
-                    <bt:Set Name="Mailbox"/>
-                </bt:Sets>
-            </Requirements>
-            <Hosts>
-                <Host xsi:type="MailHost">
-                    <DesktopFormFactor>
-                        <SupportsSharedFolders>true</SupportsSharedFolders>
-                        <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
-                            <OfficeTab id="TabDefault">
-                                <Group id="PG.PlayGroup.AA">
-                                    <Label resid="PG.GroupLabel"/>
-                                    <Control xsi:type="Button" id="PG.RunCommand.AA">
-                                        <Label resid="PG.RunCommand.Label" />
-                                        <Supertip>
-                                            <Title resid="PG.RunCommand.TipTitle" />
-                                            <Description resid="PG.RunSupertip.Desc" />
-                                        </Supertip>
-                                        <Icon>
-                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
-                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
-                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
-                                        </Icon>
-                                        <Action xsi:type="ShowTaskpane">
-                                            <SourceLocation resid="PG.Run.Url" />
-                                            <SupportsPinning>true</SupportsPinning>
-                                        </Action>
-                                    </Control>
-                                </Group>
-                            </OfficeTab>
-                        </ExtensionPoint>
-                        <ExtensionPoint xsi:type="MessageReadCommandSurface">
-                            <OfficeTab id="TabDefault">
-                                <Group id="PG.PlayGroup.MR">
-                                    <Label resid="PG.GroupLabel"/>
-                                    <Control xsi:type="Button" id="PG.RunCommand.MR">
-                                        <Label resid="PG.RunCommand.Label" />
-                                        <Supertip>
-                                            <Title resid="PG.RunCommand.TipTitle" />
-                                            <Description resid="PG.RunSupertip.Desc" />
-                                        </Supertip>
-                                        <Icon>
-                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
-                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
-                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
-                                        </Icon>
-                                        <Action xsi:type="ShowTaskpane">
-                                            <SourceLocation resid="PG.Run.Url" />
-                                            <SupportsPinning>true</SupportsPinning>
-                                        </Action>
-                                    </Control>
-                                </Group>
-                            </OfficeTab>
-                        </ExtensionPoint>
-                        <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
-                            <OfficeTab id="TabDefault">
-                                <Group id="PG.PlayGroup.AO">
-                                    <Label resid="PG.GroupLabel"/>
-                                    <Control xsi:type="Button" id="PG.RunCommand.AO">
-                                        <Label resid="PG.RunCommand.Label" />
-                                        <Supertip>
-                                            <Title resid="PG.RunCommand.TipTitle" />
-                                            <Description resid="PG.RunSupertip.Desc" />
-                                        </Supertip>
-                                        <Icon>
-                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
-                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
-                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
-                                        </Icon>
-                                        <Action xsi:type="ShowTaskpane">
-                                            <SourceLocation resid="PG.Run.Url" />
-                                            <SupportsPinning>true</SupportsPinning>
-                                        </Action>
-                                    </Control>
-                                </Group>
-                            </OfficeTab>
-                        </ExtensionPoint>
-                        <ExtensionPoint xsi:type="MessageComposeCommandSurface">
-                            <OfficeTab id="TabDefault">
-                                <Group id="PG.PlayGroup.MC">
-                                    <Label resid="PG.GroupLabel"/>
-                                    <Control xsi:type="Button" id="PG.RunCommand.MC">
-                                        <Label resid="PG.RunCommand.Label" />
-                                        <Supertip>
-                                            <Title resid="PG.RunCommand.TipTitle" />
-                                            <Description resid="PG.RunSupertip.Desc" />
-                                        </Supertip>
-                                        <Icon>
-                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
-                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
-                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
-                                        </Icon>
-                                        <Action xsi:type="ShowTaskpane">
-                                            <SourceLocation resid="PG.Run.Url" />
-                                            <SupportsPinning>true</SupportsPinning>
-                                        </Action>
-                                    </Control>
-                                </Group>
-                            </OfficeTab>
-                        </ExtensionPoint>
-                        <ExtensionPoint xsi:type="DetectedEntity">
-                            <Label resid="PG.RunCommand.Label" />
-                            <SourceLocation resid="PG.Run.Url" />
-                            <Rule xsi:type="RuleCollection" Mode="Or">
-                                <Rule xsi:type="ItemHasKnownEntity" FilterName="sampleFilterName" RegExFilter="Way" EntityType="Address" Highlight="all" />
-                                <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="sampleRegexName" RegExValue="ScriptLab" PropertyName="BodyAsPlaintext" IgnoreCase="true" Highlight="All" />
-                            </Rule>
-                        </ExtensionPoint>     
-                    </DesktopFormFactor>
-                </Host>
-            </Hosts>
-            <Resources>
-                <bt:Images>
-                    <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/icon-16.png" />
-                    <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/icon-32.png" />
-                    <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab-react.azurewebsites.net/assets/images/icon-80.png" />
-                </bt:Images>
-                <bt:Urls>
-                    <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab-react.azurewebsites.net/run.html" />
-                </bt:Urls>
-                <bt:ShortStrings>
-                    <bt:String id="PG.GroupLabel" DefaultValue="Script Lab" />
-                    <bt:String id="PG.RunCommand.Label" DefaultValue="Script Lab"></bt:String>
-                    <bt:String id="PG.RunCommand.Title" DefaultValue="Script Lab"></bt:String>
-                    <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Open Script Lab for Outlook"></bt:String>
-                </bt:ShortStrings>
-                <bt:LongStrings>
-                    <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet"></bt:String>
-                </bt:LongStrings>
-            </Resources>
+     <Requirements>
+      <bt:Sets DefaultMinVersion="1.3">
+        <bt:Set Name="Mailbox" />
+      </bt:Sets>
+    </Requirements>
+    <Hosts>
+      <Host xsi:type="MailHost">
+        <DesktopFormFactor>
+	        <SupportsSharedFolders>true</SupportsSharedFolders>
+          <FunctionFile resid="PG.Functions.Url" />
+          <ExtensionPoint xsi:type="MessageComposeCommandSurface">
+            <OfficeTab id="TabPlaygroundCompose">
+              <Group id="PG.PlayGroup.Compose">
+                <Label resid="PG.GroupLabel" />
+                <Control xsi:type="Button" id="PG.CodeCommand.Compose">
+                  <Label resid="PG.CodeCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.CodeCommand.TipTitle" />
+                    <Description resid="PG.CodeSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Code.16" />
+                    <bt:Image size="32" resid="PG.Icon.Code.32" />
+                    <bt:Image size="80" resid="PG.Icon.Code.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchCode</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.RunCommand.Compose">
+                  <Label resid="PG.RunCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.RunCommand.TipTitle" />
+                    <Description resid="PG.RunSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Run.16" />
+                    <bt:Image size="32" resid="PG.Icon.Run.32" />
+                    <bt:Image size="80" resid="PG.Icon.Run.80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="PG.Run.Url" />
+                    <SupportsPinning>true</SupportsPinning>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.TutorialCommand.Compose">
+                  <Label resid="PG.TutorialCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.TutorialCommand.TipTitle" />
+                    <Description resid="PG.TutorialCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
+                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
+                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchTutorial</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.HelpCommand.Compose">
+                  <Label resid="PG.HelpCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.HelpCommand.TipTitle" />
+                    <Description resid="PG.HelpCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Help.16" />
+                    <bt:Image size="32" resid="PG.Icon.Help.32" />
+                    <bt:Image size="80" resid="PG.Icon.Help.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchHelp</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.ApiDocsCommand.Compose">
+                  <Label resid="PG.ApiDocsCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.ApiDocsCommand.TipTitle" />
+                    <Description resid="PG.ApiDocsCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
+                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
+                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchApiDocs</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.AskCommand.Compose">
+                  <Label resid="PG.AskCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.AskCommand.TipTitle" />
+                    <Description resid="PG.AskCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
+                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
+                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchAsk</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="MessageReadCommandSurface">
+            <OfficeTab id="TabPlaygroundRead">
+              <Group id="PG.PlayGroup.Read">
+                <Label resid="PG.GroupLabel" />
+                <Control xsi:type="Button" id="PG.CodeCommand.Read">
+                  <Label resid="PG.CodeCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.CodeCommand.TipTitle" />
+                    <Description resid="PG.CodeSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Code.16" />
+                    <bt:Image size="32" resid="PG.Icon.Code.32" />
+                    <bt:Image size="80" resid="PG.Icon.Code.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchCode</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.RunCommand.Read">
+                  <Label resid="PG.RunCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.RunCommand.TipTitle" />
+                    <Description resid="PG.RunSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Run.16" />
+                    <bt:Image size="32" resid="PG.Icon.Run.32" />
+                    <bt:Image size="80" resid="PG.Icon.Run.80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="PG.Run.Url" />
+                    <SupportsPinning>true</SupportsPinning>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.TutorialCommand.Read">
+                  <Label resid="PG.TutorialCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.TutorialCommand.TipTitle" />
+                    <Description resid="PG.TutorialCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
+                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
+                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchTutorial</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.HelpCommand.Read">
+                  <Label resid="PG.HelpCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.HelpCommand.TipTitle" />
+                    <Description resid="PG.HelpCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Help.16" />
+                    <bt:Image size="32" resid="PG.Icon.Help.32" />
+                    <bt:Image size="80" resid="PG.Icon.Help.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchHelp</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.ApiDocsCommand.Read">
+                  <Label resid="PG.ApiDocsCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.ApiDocsCommand.TipTitle" />
+                    <Description resid="PG.ApiDocsCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
+                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
+                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchApiDocs</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.AskCommand.Read">
+                  <Label resid="PG.AskCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.AskCommand.TipTitle" />
+                    <Description resid="PG.AskCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
+                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
+                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchAsk</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
+            <OfficeTab id="TabPlaygroundAppointmentAttendee">
+              <Group id="PG.PlayGroup.AppointmentAttendee">
+                <Label resid="PG.GroupLabel" />
+                <Control xsi:type="Button" id="PG.CodeCommand.AppointmentAttendee">
+                  <Label resid="PG.CodeCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.CodeCommand.TipTitle" />
+                    <Description resid="PG.CodeSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Code.16" />
+                    <bt:Image size="32" resid="PG.Icon.Code.32" />
+                    <bt:Image size="80" resid="PG.Icon.Code.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchCode</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.RunCommand.AppointmentAttendee">
+                  <Label resid="PG.RunCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.RunCommand.TipTitle" />
+                    <Description resid="PG.RunSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Run.16" />
+                    <bt:Image size="32" resid="PG.Icon.Run.32" />
+                    <bt:Image size="80" resid="PG.Icon.Run.80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="PG.Run.Url" />
+                    <SupportsPinning>true</SupportsPinning>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentAttendee">
+                  <Label resid="PG.TutorialCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.TutorialCommand.TipTitle" />
+                    <Description resid="PG.TutorialCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
+                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
+                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchTutorial</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.HelpCommand.AppointmentAttendee">
+                  <Label resid="PG.HelpCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.HelpCommand.TipTitle" />
+                    <Description resid="PG.HelpCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Help.16" />
+                    <bt:Image size="32" resid="PG.Icon.Help.32" />
+                    <bt:Image size="80" resid="PG.Icon.Help.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchHelp</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.ApiDocsCommand.AppointmentAttendee">
+                  <Label resid="PG.ApiDocsCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.ApiDocsCommand.TipTitle" />
+                    <Description resid="PG.ApiDocsCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
+                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
+                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchApiDocs</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.AskCommand.AppointmentAttendee">
+                  <Label resid="PG.AskCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.AskCommand.TipTitle" />
+                    <Description resid="PG.AskCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
+                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
+                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchAsk</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+             </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+            <OfficeTab id="TabPlaygroundAppointmentOrganizer">
+              <Group id="PG.PlayGroup.AppointmentOrganizer">
+                <Label resid="PG.GroupLabel" />
+                <Control xsi:type="Button" id="PG.CodeCommand.AppointmentOrganizer">
+                  <Label resid="PG.CodeCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.CodeCommand.TipTitle" />
+                    <Description resid="PG.CodeSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Code.16" />
+                    <bt:Image size="32" resid="PG.Icon.Code.32" />
+                    <bt:Image size="80" resid="PG.Icon.Code.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchCode</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.RunCommand.AppointmentOrganizer">
+                  <Label resid="PG.RunCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.RunCommand.TipTitle" />
+                    <Description resid="PG.RunSupertip.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Run.16" />
+                    <bt:Image size="32" resid="PG.Icon.Run.32" />
+                    <bt:Image size="80" resid="PG.Icon.Run.80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="PG.Run.Url" />
+                    <SupportsPinning>true</SupportsPinning>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentOrganizer">
+                  <Label resid="PG.TutorialCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.TutorialCommand.TipTitle" />
+                    <Description resid="PG.TutorialCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
+                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
+                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchTutorial</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.HelpCommand.AppointmentOrganizer">
+                  <Label resid="PG.HelpCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.HelpCommand.TipTitle" />
+                    <Description resid="PG.HelpCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Help.16" />
+                    <bt:Image size="32" resid="PG.Icon.Help.32" />
+                    <bt:Image size="80" resid="PG.Icon.Help.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchHelp</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.ApiDocsCommand.AppointmentOrganizer">
+                  <Label resid="PG.ApiDocsCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.ApiDocsCommand.TipTitle" />
+                    <Description resid="PG.ApiDocsCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
+                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
+                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchApiDocs</FunctionName>
+                  </Action>
+                </Control>
+                <Control xsi:type="Button" id="PG.AskCommand.AppointmentOrganizer">
+                  <Label resid="PG.AskCommand.Label" />
+                  <Supertip>
+                    <Title resid="PG.AskCommand.TipTitle" />
+                    <Description resid="PG.AskCommand.Desc" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
+                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
+                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
+                  </Icon>
+                  <Action xsi:type="ExecuteFunction">
+                    <FunctionName>launchAsk</FunctionName>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+    </Hosts>
+    <Resources>
+      <bt:Images>
+        <bt:Image id="PG.Icon.16" DefaultValue="https://script-lab.azureedge.net/assets/images/icon-16.png" />
+        <bt:Image id="PG.Icon.32" DefaultValue="https://script-lab.azureedge.net/assets/images/icon-32.png" />
+        <bt:Image id="PG.Icon.80" DefaultValue="https://script-lab.azureedge.net/assets/images/icon-80.png" />
+        <bt:Image id="PG.Icon.Code.16" DefaultValue="https://script-lab.azureedge.net/assets/images/code-16.png" />
+        <bt:Image id="PG.Icon.Code.32" DefaultValue="https://script-lab.azureedge.net/assets/images/code-32.png" />
+        <bt:Image id="PG.Icon.Code.80" DefaultValue="https://script-lab.azureedge.net/assets/images/code-80.png" />
+        <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab.azureedge.net/assets/images/run-16.png" />
+        <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab.azureedge.net/assets/images/run-32.png" />
+        <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab.azureedge.net/assets/images/run-80.png" />
+        <bt:Image id="PG.Icon.Tutorial.16" DefaultValue="https://script-lab.azureedge.net/assets/images/tutorial-16.png" />
+        <bt:Image id="PG.Icon.Tutorial.32" DefaultValue="https://script-lab.azureedge.net/assets/images/tutorial-32.png" />
+        <bt:Image id="PG.Icon.Tutorial.80" DefaultValue="https://script-lab.azureedge.net/assets/images/tutorial-80.png" />
+        <bt:Image id="PG.Icon.Help.16" DefaultValue="https://script-lab.azureedge.net/assets/images/help-16.png" />
+        <bt:Image id="PG.Icon.Help.32" DefaultValue="https://script-lab.azureedge.net/assets/images/help-32.png" />
+        <bt:Image id="PG.Icon.Help.80" DefaultValue="https://script-lab.azureedge.net/assets/images/help-80.png" />
+        <bt:Image id="PG.Icon.ApiDocs.16" DefaultValue="https://script-lab.azureedge.net/assets/images/docs-16.png" />
+        <bt:Image id="PG.Icon.ApiDocs.32" DefaultValue="https://script-lab.azureedge.net/assets/images/docs-32.png" />
+        <bt:Image id="PG.Icon.ApiDocs.80" DefaultValue="https://script-lab.azureedge.net/assets/images/docs-80.png" />
+        <bt:Image id="PG.Icon.Ask.16" DefaultValue="https://script-lab.azureedge.net/assets/images/ask-16.png" />
+        <bt:Image id="PG.Icon.Ask.32" DefaultValue="https://script-lab.azureedge.net/assets/images/ask-32.png" />
+        <bt:Image id="PG.Icon.Ask.80" DefaultValue="https://script-lab.azureedge.net/assets/images/ask-80.png" />
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab.azureedge.net/run.html" />
+        <bt:Url id="PG.Functions.Url" DefaultValue="https://script-lab.azureedge.net/functions.html" />
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="PG.TabLabel" DefaultValue="Script Lab" />
+        <bt:String id="PG.GroupLabel" DefaultValue="Script Lab" />
+        <bt:String id="PG.AboutGroupLabel" DefaultValue="About Script Lab">
+          <bt:Override Locale="de-de" Value="Über Script Lab"/>
+          <bt:Override Locale="de-ch" Value="Über Script Lab"/>
+          <bt:Override Locale="de-at" Value="Über Script Lab"/>
+          <bt:Override Locale="es-ar" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-bo" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-cl" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-co" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-cr" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-do" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-ec" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-sv" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-gt" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-hn" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-ni" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-pa" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-py" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-pe" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-pr" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-es" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-uy" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Acerca de Script Lab"/>
+          <bt:Override Locale="zh-cn" Value="关于Script Lab"/>
+        </bt:String>
+        <bt:String id="PG.ApiGroupLabel" DefaultValue="About the APIs">
+          <bt:Override Locale="de-de" Value="Über die APIs"/>
+          <bt:Override Locale="de-ch" Value="Über die APIs"/>
+          <bt:Override Locale="de-at" Value="Über die APIs"/>
+          <bt:Override Locale="es-ar" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-bo" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-cl" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-co" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-cr" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-do" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-ec" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-sv" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-gt" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-hn" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-mx" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-ni" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-pa" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-py" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-pe" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-pr" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-es" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-uy" Value="Acerca de las APIs"/>
+          <bt:Override Locale="es-mx" Value="Acerca de las APIs"/>
+          <bt:Override Locale="zh-cn" Value="关于APIs"/>
+        </bt:String>
+        <bt:String id="PG.CodeCommand.Label" DefaultValue="Code">
+          <bt:Override Locale="zh-cn" Value="代码"/>
+        </bt:String>
+        <bt:String id="PG.CodeCommand.Title" DefaultValue="Code">
+          <bt:Override Locale="zh-cn" Value="代码"/>
+        </bt:String>
+        <bt:String id="PG.CodeCommand.TipTitle" DefaultValue="Create or edit code snippets">
+          <bt:Override Locale="de-de" Value="Erstellen oder Editieren von Code-Schnipseln"/>
+          <bt:Override Locale="de-ch" Value="Erstellen oder Editieren von Code-Schnipseln"/>
+          <bt:Override Locale="de-at" Value="Erstellen oder Editieren von Code-Schnipseln"/>
+          <bt:Override Locale="es-ar" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-bo" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-cl" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-co" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-cr" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-do" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-ec" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-sv" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-gt" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-hn" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-mx" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-ni" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-pa" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-py" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-pe" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-pr" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-es" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-uy" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="es-mx" Value="Crea o edita fragmentos de código"/>
+          <bt:Override Locale="zh-cn" Value="创建或编辑代码段"/>
+        </bt:String>
+        <bt:String id="PG.RunCommand.Label" DefaultValue="Run">
+          <bt:Override Locale="de-de" Value="Ausführen"/>
+          <bt:Override Locale="de-ch" Value="Ausführen"/>
+          <bt:Override Locale="de-at" Value="Ausführen"/>
+          <bt:Override Locale="es-ar" Value="Ejecutar"/>
+          <bt:Override Locale="es-bo" Value="Ejecutar"/>
+          <bt:Override Locale="es-cl" Value="Ejecutar"/>
+          <bt:Override Locale="es-co" Value="Ejecutar"/>
+          <bt:Override Locale="es-cr" Value="Ejecutar"/>
+          <bt:Override Locale="es-do" Value="Ejecutar"/>
+          <bt:Override Locale="es-ec" Value="Ejecutar"/>
+          <bt:Override Locale="es-sv" Value="Ejecutar"/>
+          <bt:Override Locale="es-gt" Value="Ejecutar"/>
+          <bt:Override Locale="es-hn" Value="Ejecutar"/>
+          <bt:Override Locale="es-mx" Value="Ejecutar"/>
+          <bt:Override Locale="es-ni" Value="Ejecutar"/>
+          <bt:Override Locale="es-pa" Value="Ejecutar"/>
+          <bt:Override Locale="es-py" Value="Ejecutar"/>
+          <bt:Override Locale="es-pe" Value="Ejecutar"/>
+          <bt:Override Locale="es-pr" Value="Ejecutar"/>
+          <bt:Override Locale="es-es" Value="Ejecutar"/>
+          <bt:Override Locale="es-uy" Value="Ejecutar"/>
+          <bt:Override Locale="es-mx" Value="Ejecutar"/>
+          <bt:Override Locale="zh-cn" Value="运行"/>
+        </bt:String>
+        <bt:String id="PG.RunCommand.Title" DefaultValue="Run">
+          <bt:Override Locale="de-de" Value="Ausführen"/>
+          <bt:Override Locale="de-ch" Value="Ausführen"/>
+          <bt:Override Locale="de-at" Value="Ausführen"/>
+          <bt:Override Locale="es-ar" Value="Ejecutar"/>
+          <bt:Override Locale="es-bo" Value="Ejecutar"/>
+          <bt:Override Locale="es-cl" Value="Ejecutar"/>
+          <bt:Override Locale="es-co" Value="Ejecutar"/>
+          <bt:Override Locale="es-cr" Value="Ejecutar"/>
+          <bt:Override Locale="es-do" Value="Ejecutar"/>
+          <bt:Override Locale="es-ec" Value="Ejecutar"/>
+          <bt:Override Locale="es-sv" Value="Ejecutar"/>
+          <bt:Override Locale="es-gt" Value="Ejecutar"/>
+          <bt:Override Locale="es-hn" Value="Ejecutar"/>
+          <bt:Override Locale="es-mx" Value="Ejecutar"/>
+          <bt:Override Locale="es-ni" Value="Ejecutar"/>
+          <bt:Override Locale="es-pa" Value="Ejecutar"/>
+          <bt:Override Locale="es-py" Value="Ejecutar"/>
+          <bt:Override Locale="es-pe" Value="Ejecutar"/>
+          <bt:Override Locale="es-pr" Value="Ejecutar"/>
+          <bt:Override Locale="es-es" Value="Ejecutar"/>
+          <bt:Override Locale="es-uy" Value="Ejecutar"/>
+          <bt:Override Locale="es-mx" Value="Ejecutar"/>
+          <bt:Override Locale="zh-cn" Value="运行"/>
+        </bt:String>
+        <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Run the code snippet">
+          <bt:Override Locale="de-de" Value="Code-Schnipsel ausführen"/>
+          <bt:Override Locale="de-ch" Value="Code-Schnipsel ausführen"/>
+          <bt:Override Locale="de-at" Value="Code-Schnipsel ausführen"/>
+          <bt:Override Locale="es-ar" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-bo" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-cl" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-co" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-cr" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-do" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-ec" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-sv" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-gt" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-hn" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-mx" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-ni" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-pa" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-py" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-pe" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-pr" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-es" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-uy" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="es-mx" Value="Ejecuta el fragmento de código"/>
+          <bt:Override Locale="zh-cn" Value="运行代码段"/>
+        </bt:String>
+        <bt:String id="PG.TutorialCommand.Label" DefaultValue="Tutorial">
+          <bt:Override Locale="zh-cn" Value="教程"/>
+        </bt:String>
+        <bt:String id="PG.TutorialCommand.TipTitle" DefaultValue="Script Lab tutorial">
+          <bt:Override Locale="de-de" Value="Tutorial zu Script Lab"/>
+          <bt:Override Locale="de-ch" Value="Tutorial zu Script Lab"/>
+          <bt:Override Locale="de-at" Value="Tutorial zu Script Lab"/>
+          <bt:Override Locale="es-ar" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-bo" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-cl" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-co" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-cr" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-do" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-ec" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-sv" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-gt" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-hn" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-ni" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-pa" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-py" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-pe" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-pr" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-es" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-uy" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Tutorial de Script Lab"/>
+          <bt:Override Locale="zh-cn" Value="Script Lab教程"/>
+        </bt:String>
+        <bt:String id="PG.HelpCommand.Label" DefaultValue="Help">
+          <bt:Override Locale="de-de" Value="Hilfe"/>
+          <bt:Override Locale="de-ch" Value="Hilfe"/>
+          <bt:Override Locale="de-at" Value="Hilfe"/>
+          <bt:Override Locale="es-ar" Value="Ayuda"/>
+          <bt:Override Locale="es-bo" Value="Ayuda"/>
+          <bt:Override Locale="es-cl" Value="Ayuda"/>
+          <bt:Override Locale="es-co" Value="Ayuda"/>
+          <bt:Override Locale="es-cr" Value="Ayuda"/>
+          <bt:Override Locale="es-do" Value="Ayuda"/>
+          <bt:Override Locale="es-ec" Value="Ayuda"/>
+          <bt:Override Locale="es-sv" Value="Ayuda"/>
+          <bt:Override Locale="es-gt" Value="Ayuda"/>
+          <bt:Override Locale="es-hn" Value="Ayuda"/>
+          <bt:Override Locale="es-mx" Value="Ayuda"/>
+          <bt:Override Locale="es-ni" Value="Ayuda"/>
+          <bt:Override Locale="es-pa" Value="Ayuda"/>
+          <bt:Override Locale="es-py" Value="Ayuda"/>
+          <bt:Override Locale="es-pe" Value="Ayuda"/>
+          <bt:Override Locale="es-pr" Value="Ayuda"/>
+          <bt:Override Locale="es-es" Value="Ayuda"/>
+          <bt:Override Locale="es-uy" Value="Ayuda"/>
+          <bt:Override Locale="es-mx" Value="Ayuda"/>
+          <bt:Override Locale="zh-cn" Value="帮助"/>
+        </bt:String>
+        <bt:String id="PG.HelpCommand.TipTitle" DefaultValue="Help for Script Lab">
+          <bt:Override Locale="de-de" Value="Hilfe zu Script Lab"/>
+          <bt:Override Locale="de-ch" Value="Hilfe zu Script Lab"/>
+          <bt:Override Locale="de-at" Value="Hilfe zu Script Lab"/>
+          <bt:Override Locale="es-ar" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-bo" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-cl" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-co" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-cr" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-do" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-ec" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-sv" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-gt" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-hn" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-ni" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-pa" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-py" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-pe" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-pr" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-es" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-uy" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="es-mx" Value="Ayuda de Script Lab"/>
+          <bt:Override Locale="zh-cn" Value="Script Lab的帮助信息"/>
+        </bt:String>
+       <bt:String id="PG.ApiDocsCommand.Label" DefaultValue="Reference Docs">
+          <bt:Override Locale="de-de" Value="Dokumentation"/>
+          <bt:Override Locale="de-ch" Value="Dokumentation"/>
+          <bt:Override Locale="de-at" Value="Dokumentation"/>
+          <bt:Override Locale="es-ar" Value="Documentación"/>
+          <bt:Override Locale="es-bo" Value="Documentación"/>
+          <bt:Override Locale="es-cl" Value="Documentación"/>
+          <bt:Override Locale="es-co" Value="Documentación"/>
+          <bt:Override Locale="es-cr" Value="Documentación"/>
+          <bt:Override Locale="es-do" Value="Documentación"/>
+          <bt:Override Locale="es-ec" Value="Documentación"/>
+          <bt:Override Locale="es-sv" Value="Documentación"/>
+          <bt:Override Locale="es-gt" Value="Documentación"/>
+          <bt:Override Locale="es-hn" Value="Documentación"/>
+          <bt:Override Locale="es-mx" Value="Documentación"/>
+          <bt:Override Locale="es-ni" Value="Documentación"/>
+          <bt:Override Locale="es-pa" Value="Documentación"/>
+          <bt:Override Locale="es-py" Value="Documentación"/>
+          <bt:Override Locale="es-pe" Value="Documentación"/>
+          <bt:Override Locale="es-pr" Value="Documentación"/>
+          <bt:Override Locale="es-es" Value="Documentación"/>
+          <bt:Override Locale="es-uy" Value="Documentación"/>
+          <bt:Override Locale="es-mx" Value="Documentación"/>
+          <bt:Override Locale="zh-cn" Value="参考文档"/>
+        </bt:String>
+        <bt:String id="PG.ApiDocsCommand.TipTitle" DefaultValue="API Reference Documentation">
+          <bt:Override Locale="de-de" Value="API-Dokumentation"/>
+          <bt:Override Locale="de-ch" Value="API-Dokumentation"/>
+          <bt:Override Locale="de-at" Value="API-Dokumentation"/>
+          <bt:Override Locale="es-ar" Value="Documentación de la API"/>
+          <bt:Override Locale="es-bo" Value="Documentación de la API"/>
+          <bt:Override Locale="es-cl" Value="Documentación de la API"/>
+          <bt:Override Locale="es-co" Value="Documentación de la API"/>
+          <bt:Override Locale="es-cr" Value="Documentación de la API"/>
+          <bt:Override Locale="es-do" Value="Documentación de la API"/>
+          <bt:Override Locale="es-ec" Value="Documentación de la API"/>
+          <bt:Override Locale="es-sv" Value="Documentación de la API"/>
+          <bt:Override Locale="es-gt" Value="Documentación de la API"/>
+          <bt:Override Locale="es-hn" Value="Documentación de la API"/>
+          <bt:Override Locale="es-mx" Value="Documentación de la API"/>
+          <bt:Override Locale="es-ni" Value="Documentación de la API"/>
+          <bt:Override Locale="es-pa" Value="Documentación de la API"/>
+          <bt:Override Locale="es-py" Value="Documentación de la API"/>
+          <bt:Override Locale="es-pe" Value="Documentación de la API"/>
+          <bt:Override Locale="es-pr" Value="Documentación de la API"/>
+          <bt:Override Locale="es-es" Value="Documentación de la API"/>
+          <bt:Override Locale="es-uy" Value="Documentación de la API"/>
+          <bt:Override Locale="es-mx" Value="Documentación de la API"/>
+          <bt:Override Locale="zh-cn" Value="API参考文档"/>
+        </bt:String>
+        <bt:String id="PG.AskCommand.Label" DefaultValue="Ask the Community">
+          <bt:Override Locale="de-de" Value="Community"/>
+          <bt:Override Locale="de-ch" Value="Community"/>
+          <bt:Override Locale="de-at" Value="Community"/>
+          <bt:Override Locale="es-ar" Value="Comunidad"/>
+          <bt:Override Locale="es-bo" Value="Comunidad"/>
+          <bt:Override Locale="es-cl" Value="Comunidad"/>
+          <bt:Override Locale="es-co" Value="Comunidad"/>
+          <bt:Override Locale="es-cr" Value="Comunidad"/>
+          <bt:Override Locale="es-do" Value="Comunidad"/>
+          <bt:Override Locale="es-ec" Value="Comunidad"/>
+          <bt:Override Locale="es-sv" Value="Comunidad"/>
+          <bt:Override Locale="es-gt" Value="Comunidad"/>
+          <bt:Override Locale="es-hn" Value="Comunidad"/>
+          <bt:Override Locale="es-mx" Value="Comunidad"/>
+          <bt:Override Locale="es-ni" Value="Comunidad"/>
+          <bt:Override Locale="es-pa" Value="Comunidad"/>
+          <bt:Override Locale="es-py" Value="Comunidad"/>
+          <bt:Override Locale="es-pe" Value="Comunidad"/>
+          <bt:Override Locale="es-pr" Value="Comunidad"/>
+          <bt:Override Locale="es-es" Value="Comunidad"/>
+          <bt:Override Locale="es-uy" Value="Comunidad"/>
+          <bt:Override Locale="es-mx" Value="Comunidad"/>
+          <bt:Override Locale="zh-cn" Value="询问社区"/>
+        </bt:String>
+        <bt:String id="PG.AskCommand.TipTitle" DefaultValue="Get API help from the community">
+          <bt:Override Locale="de-de" Value="Unterstützung durch die Community"/>
+          <bt:Override Locale="de-ch" Value="Unterstützung durch die Community"/>
+          <bt:Override Locale="de-at" Value="Unterstützung durch die Community"/>
+          <bt:Override Locale="es-ar" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-bo" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-cl" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-co" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-cr" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-do" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-ec" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-sv" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-gt" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-hn" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-mx" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-ni" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-pa" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-py" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-pe" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-pr" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-es" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-uy" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="es-mx" Value="Obtén ayuda de nuestra comunidad"/>
+          <bt:Override Locale="zh-cn" Value="从社区获取API帮助"/>
+        </bt:String>
+        <bt:String id="PG.CFNamespace" DefaultValue="SCRIPTLAB" />
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="PG.CodeSupertip.Desc" DefaultValue="Opens the Script Lab code editor">
+          <bt:Override Locale="de-de" Value="Den Script Lab Code-Editor aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Den Script Lab Code-Editor aufrufen."/>
+          <bt:Override Locale="de-at" Value="Den Script Lab Code-Editor aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-bo" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-cl" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-co" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-cr" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-do" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-ec" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-sv" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-gt" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-hn" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-ni" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-pa" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-py" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-pe" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-pr" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-es" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-uy" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre el editor de código de Script Lab."/>
+          <bt:Override Locale="zh-cn" Value="打开Script Lab代码编辑器"/>
+        </bt:String>
+        <bt:String id="PG.CFSupertip.Desc" DefaultValue="Launch the Custom Functions dashboard">
+          <bt:Override Locale="de-de" Value="Den Aufgabenbereich zu den benutzerdefinierten Funktionen aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Den Aufgabenbereich zu den benutzerdefinierten Funktionen aufrufen."/>
+          <bt:Override Locale="de-at" Value="Den Aufgabenbereich zu den benutzerdefinierten Funktionen aufrufen."/>
+        </bt:String>
+        <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet">
+          <bt:Override Locale="de-de" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
+          <bt:Override Locale="de-at" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-bo" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-cl" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-co" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-cr" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-do" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-ec" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-sv" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-gt" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-hn" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-mx" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-ni" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-pa" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-py" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-pe" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-pr" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-es" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-uy" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="es-mx" Value="Abre el panel que ejecuta el fragmento de código actual."/>
+          <bt:Override Locale="zh-cn" Value="打开运行当前代码段的任务窗格"/>
+        </bt:String>
+        <bt:String id="PG.TutorialCommand.Desc" DefaultValue="Launches a quick Script Lab tutorial">
+          <bt:Override Locale="de-de" Value="Ein Tutorial zu Script Lab aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Ein Tutorial zu Script Lab aufrufen."/>
+          <bt:Override Locale="de-at" Value="Ein Tutorial zu Script Lab aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-bo" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-cl" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-co" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-cr" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-do" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-ec" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-sv" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-gt" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-hn" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-ni" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-pa" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-py" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-pe" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-pr" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-es" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-uy" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre un breve tutorial de Script Lab."/>
+          <bt:Override Locale="zh-cn" Value="启动Script Lab快速教程"/>
+        </bt:String>
+        <bt:String id="PG.HelpCommand.Desc" DefaultValue="Launches documentation on using Script Lab">
+          <bt:Override Locale="de-de" Value="Die Dokumentation zu Script Lab aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Die Dokumentation zu Script Lab aufrufen."/>
+          <bt:Override Locale="de-at" Value="Die Dokumentation zu Script Lab aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-bo" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-cl" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-co" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-cr" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-do" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-ec" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-sv" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-gt" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-hn" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-ni" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-pa" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-py" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-pe" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-pr" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-es" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-uy" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="es-mx" Value="Abre la documentación acerca del uso de Script Lab."/>
+          <bt:Override Locale="zh-cn" Value="启动Script Lab文档"/>
+        </bt:String>
+        <bt:String id="PG.ApiDocsCommand.Desc" DefaultValue="Opens the API documentation for the Office application that you are running">
+          <bt:Override Locale="de-de" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
+          <bt:Override Locale="de-at" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-bo" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-cl" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-co" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-cr" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-do" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-ec" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-sv" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-gt" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-hn" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-mx" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-ni" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-pa" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-py" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-pe" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-pr" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-es" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-uy" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="es-mx" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
+          <bt:Override Locale="zh-cn" Value="打开正在运行的Office应用程序的API文档"/>
+        </bt:String>
+        <bt:String id="PG.AskCommand.Desc" DefaultValue="Launches a community forum for questions about the Office JavaScript APIs">
+          <bt:Override Locale="de-de" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
+          <bt:Override Locale="de-ch" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
+          <bt:Override Locale="de-at" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
+          <bt:Override Locale="es-ar" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-bo" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-cl" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-co" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-cr" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-do" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-ec" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-sv" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-gt" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-hn" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-mx" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-ni" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-pa" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-py" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-pe" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-pr" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-es" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-uy" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="es-mx" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
+          <bt:Override Locale="zh-cn" Value="启动社区论坛来讨论有关Office JavaScript API的问题"/>
+        </bt:String>
+        <bt:String id="PG.Description" DefaultValue="Code, run, and share your Add-in snippets directly from Office.">
+          <bt:Override Locale="de-de" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
+          <bt:Override Locale="de-ch" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
+          <bt:Override Locale="de-at" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
+          <bt:Override Locale="es-ar" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-bo" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-cl" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-co" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-cr" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-do" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-ec" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-sv" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-gt" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-hn" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-mx" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-ni" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-pa" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-py" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-pe" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-pr" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-es" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-uy" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="es-mx" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
+          <bt:Override Locale="zh-cn" Value="直接从Office中编码、运行和共享代码段。"/>
+        </bt:String>
+      </bt:LongStrings>
+    </Resources>
         </VersionOverrides>
     </VersionOverrides>
 </OfficeApp>

--- a/manifests/script-lab-react-prod.outlook.xml
+++ b/manifests/script-lab-react-prod.outlook.xml
@@ -9,8 +9,8 @@
     <DefaultLocale>en-US</DefaultLocale>
     <DisplayName DefaultValue="Script Lab for Outlook" />
     <Description DefaultValue="Create, run, and share your Office Add-in code snippets from within Outlook."></Description>
-    <IconUrl DefaultValue="https://script-lab.azureedge.net/assets/images/icon-64.png" />
-    <HighResolutionIconUrl DefaultValue="https://script-lab.azureedge.net/assets/images/icon-64.png" />
+    <IconUrl DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-64.png" />
+    <HighResolutionIconUrl DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-64.png" />
     <SupportUrl DefaultValue="https://github.com/OfficeDev/script-lab/issues" />
     <AppDomains>
         <AppDomain>https://github.com</AppDomain>
@@ -52,7 +52,7 @@
     <FormSettings>
         <Form xsi:type="ItemRead">
             <DesktopSettings>
-                <SourceLocation DefaultValue="https://script-lab.azureedge.net" />
+                <SourceLocation DefaultValue="https://script-lab-react-alpha.azurewebsites.net" />
                 <RequestedHeight>450</RequestedHeight>
             </DesktopSettings>
         </Form>
@@ -164,15 +164,16 @@
         </Hosts>
         <Resources>
             <bt:Images>
-              <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab.azureedge.net/assets/images/code-16.png" />
-              <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab.azureedge.net/assets/images/code-32.png" />
-              <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab.azureedge.net/assets/images/code-80.png" />
+                <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/run-16.png" />
+                <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/run-32.png" />
+                <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/run-80.png" />
             </bt:Images>
             <bt:Urls>
-                <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab.azureedge.net/run.html" />
+                <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/run.html" />
             </bt:Urls>
             <bt:ShortStrings>
-                <bt:String id="PG.GroupLabel" DefaultValue="Script Lab" />
+
+                <bt:String id="PG.GroupLabel" DefaultValue="Script Lab [ALPHA]" />
                 <bt:String id="PG.RunCommand.Label" DefaultValue="Script Lab"></bt:String>
                 <bt:String id="PG.RunCommand.Title" DefaultValue="Script Lab"></bt:String>
                 <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Open Script Lab for Outlook"></bt:String>
@@ -183,989 +184,137 @@
         </Resources>
         <!-- Version Overrides 1.1-->
         <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
-     <Requirements>
-      <bt:Sets DefaultMinVersion="1.3">
-        <bt:Set Name="Mailbox" />
-      </bt:Sets>
-    </Requirements>
-    <Hosts>
-      <Host xsi:type="MailHost">
-        <DesktopFormFactor>
-	        <SupportsSharedFolders>true</SupportsSharedFolders>
-          <FunctionFile resid="PG.Functions.Url" />
-          <ExtensionPoint xsi:type="MessageComposeCommandSurface">
-            <CustomTab id="TabPlaygroundCompose">
-              <Group id="PG.PlayGroup.Compose">
-                <Label resid="PG.GroupLabel" />
-                <Control xsi:type="Button" id="PG.CodeCommand.Compose">
-                  <Label resid="PG.CodeCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.CodeCommand.TipTitle" />
-                    <Description resid="PG.CodeSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Code.16" />
-                    <bt:Image size="32" resid="PG.Icon.Code.32" />
-                    <bt:Image size="80" resid="PG.Icon.Code.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchCode</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.RunCommand.Compose">
-                  <Label resid="PG.RunCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.RunCommand.TipTitle" />
-                    <Description resid="PG.RunSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Run.16" />
-                    <bt:Image size="32" resid="PG.Icon.Run.32" />
-                    <bt:Image size="80" resid="PG.Icon.Run.80" />
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="PG.Run.Url" />
-                    <SupportsPinning>true</SupportsPinning>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.AboutGroup.Compose">
-                <Label resid="PG.AboutGroupLabel" />
-                <Control xsi:type="Button" id="PG.TutorialCommand.Compose">
-                  <Label resid="PG.TutorialCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.TutorialCommand.TipTitle" />
-                    <Description resid="PG.TutorialCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
-                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
-                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchTutorial</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.HelpCommand.Compose">
-                  <Label resid="PG.HelpCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.HelpCommand.TipTitle" />
-                    <Description resid="PG.HelpCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Help.16" />
-                    <bt:Image size="32" resid="PG.Icon.Help.32" />
-                    <bt:Image size="80" resid="PG.Icon.Help.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchHelp</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.ApiGroup.Compose">
-                <Label resid="PG.ApiGroupLabel" />
-                <Control xsi:type="Button" id="PG.ApiDocsCommand.Compose">
-                  <Label resid="PG.ApiDocsCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.ApiDocsCommand.TipTitle" />
-                    <Description resid="PG.ApiDocsCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
-                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
-                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchApiDocs</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.AskCommand.Compose">
-                  <Label resid="PG.AskCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.AskCommand.TipTitle" />
-                    <Description resid="PG.AskCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
-                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
-                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchAsk</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Label resid="PG.TabLabel" />
-            </CustomTab>
-          </ExtensionPoint>
-          <ExtensionPoint xsi:type="MessageReadCommandSurface">
-            <CustomTab id="TabPlaygroundRead">
-              <Group id="PG.PlayGroup.Read">
-                <Label resid="PG.GroupLabel" />
-                <Control xsi:type="Button" id="PG.CodeCommand.Read">
-                  <Label resid="PG.CodeCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.CodeCommand.TipTitle" />
-                    <Description resid="PG.CodeSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Code.16" />
-                    <bt:Image size="32" resid="PG.Icon.Code.32" />
-                    <bt:Image size="80" resid="PG.Icon.Code.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchCode</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.RunCommand.Read">
-                  <Label resid="PG.RunCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.RunCommand.TipTitle" />
-                    <Description resid="PG.RunSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Run.16" />
-                    <bt:Image size="32" resid="PG.Icon.Run.32" />
-                    <bt:Image size="80" resid="PG.Icon.Run.80" />
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="PG.Run.Url" />
-                    <SupportsPinning>true</SupportsPinning>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.AboutGroup.Read">
-                <Label resid="PG.AboutGroupLabel" />
-                <Control xsi:type="Button" id="PG.TutorialCommand.Read">
-                  <Label resid="PG.TutorialCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.TutorialCommand.TipTitle" />
-                    <Description resid="PG.TutorialCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
-                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
-                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchTutorial</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.HelpCommand.Read">
-                  <Label resid="PG.HelpCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.HelpCommand.TipTitle" />
-                    <Description resid="PG.HelpCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Help.16" />
-                    <bt:Image size="32" resid="PG.Icon.Help.32" />
-                    <bt:Image size="80" resid="PG.Icon.Help.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchHelp</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.ApiGroup.Read">
-                <Label resid="PG.ApiGroupLabel" />
-                <Control xsi:type="Button" id="PG.ApiDocsCommand.Read">
-                  <Label resid="PG.ApiDocsCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.ApiDocsCommand.TipTitle" />
-                    <Description resid="PG.ApiDocsCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
-                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
-                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchApiDocs</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.AskCommand.Read">
-                  <Label resid="PG.AskCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.AskCommand.TipTitle" />
-                    <Description resid="PG.AskCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
-                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
-                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchAsk</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Label resid="PG.TabLabel" />
-            </CustomTab>
-          </ExtensionPoint>
-          <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
-            <CustomTab id="TabPlaygroundAppointmentAttendee">
-              <Group id="PG.PlayGroup.AppointmentAttendee">
-                <Label resid="PG.GroupLabel" />
-                <Control xsi:type="Button" id="PG.CodeCommand.AppointmentAttendee">
-                  <Label resid="PG.CodeCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.CodeCommand.TipTitle" />
-                    <Description resid="PG.CodeSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Code.16" />
-                    <bt:Image size="32" resid="PG.Icon.Code.32" />
-                    <bt:Image size="80" resid="PG.Icon.Code.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchCode</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.RunCommand.AppointmentAttendee">
-                  <Label resid="PG.RunCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.RunCommand.TipTitle" />
-                    <Description resid="PG.RunSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Run.16" />
-                    <bt:Image size="32" resid="PG.Icon.Run.32" />
-                    <bt:Image size="80" resid="PG.Icon.Run.80" />
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="PG.Run.Url" />
-                    <SupportsPinning>true</SupportsPinning>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.AboutGroup.AppointmentAttendee">
-                <Label resid="PG.AboutGroupLabel" />
-                <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentAttendee">
-                  <Label resid="PG.TutorialCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.TutorialCommand.TipTitle" />
-                    <Description resid="PG.TutorialCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
-                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
-                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchTutorial</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.HelpCommand.AppointmentAttendee">
-                  <Label resid="PG.HelpCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.HelpCommand.TipTitle" />
-                    <Description resid="PG.HelpCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Help.16" />
-                    <bt:Image size="32" resid="PG.Icon.Help.32" />
-                    <bt:Image size="80" resid="PG.Icon.Help.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchHelp</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.ApiGroup.AppointmentAttendee">
-                <Label resid="PG.ApiGroupLabel" />
-                <Control xsi:type="Button" id="PG.ApiDocsCommand.AppointmentAttendee">
-                  <Label resid="PG.ApiDocsCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.ApiDocsCommand.TipTitle" />
-                    <Description resid="PG.ApiDocsCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
-                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
-                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchApiDocs</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.AskCommand.AppointmentAttendee">
-                  <Label resid="PG.AskCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.AskCommand.TipTitle" />
-                    <Description resid="PG.AskCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
-                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
-                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchAsk</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Label resid="PG.TabLabel" />
-            </CustomTab>
-          </ExtensionPoint>
-          <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
-            <CustomTab id="TabPlaygroundAppointmentOrganizer">
-              <Group id="PG.PlayGroup.AppointmentOrganizer">
-                <Label resid="PG.GroupLabel" />
-                <Control xsi:type="Button" id="PG.CodeCommand.AppointmentOrganizer">
-                  <Label resid="PG.CodeCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.CodeCommand.TipTitle" />
-                    <Description resid="PG.CodeSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Code.16" />
-                    <bt:Image size="32" resid="PG.Icon.Code.32" />
-                    <bt:Image size="80" resid="PG.Icon.Code.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchCode</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.RunCommand.AppointmentOrganizer">
-                  <Label resid="PG.RunCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.RunCommand.TipTitle" />
-                    <Description resid="PG.RunSupertip.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Run.16" />
-                    <bt:Image size="32" resid="PG.Icon.Run.32" />
-                    <bt:Image size="80" resid="PG.Icon.Run.80" />
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="PG.Run.Url" />
-                    <SupportsPinning>true</SupportsPinning>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.AboutGroup.AppointmentOrganizer">
-                <Label resid="PG.AboutGroupLabel" />
-                <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentOrganizer">
-                  <Label resid="PG.TutorialCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.TutorialCommand.TipTitle" />
-                    <Description resid="PG.TutorialCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Tutorial.16" />
-                    <bt:Image size="32" resid="PG.Icon.Tutorial.32" />
-                    <bt:Image size="80" resid="PG.Icon.Tutorial.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchTutorial</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.HelpCommand.AppointmentOrganizer">
-                  <Label resid="PG.HelpCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.HelpCommand.TipTitle" />
-                    <Description resid="PG.HelpCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Help.16" />
-                    <bt:Image size="32" resid="PG.Icon.Help.32" />
-                    <bt:Image size="80" resid="PG.Icon.Help.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchHelp</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Group id="PG.ApiGroup.AppointmentOrganizer">
-                <Label resid="PG.ApiGroupLabel" />
-                <Control xsi:type="Button" id="PG.ApiDocsCommand.AppointmentOrganizer">
-                  <Label resid="PG.ApiDocsCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.ApiDocsCommand.TipTitle" />
-                    <Description resid="PG.ApiDocsCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.ApiDocs.16" />
-                    <bt:Image size="32" resid="PG.Icon.ApiDocs.32" />
-                    <bt:Image size="80" resid="PG.Icon.ApiDocs.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchApiDocs</FunctionName>
-                  </Action>
-                </Control>
-                <Control xsi:type="Button" id="PG.AskCommand.AppointmentOrganizer">
-                  <Label resid="PG.AskCommand.Label" />
-                  <Supertip>
-                    <Title resid="PG.AskCommand.TipTitle" />
-                    <Description resid="PG.AskCommand.Desc" />
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="PG.Icon.Ask.16" />
-                    <bt:Image size="32" resid="PG.Icon.Ask.32" />
-                    <bt:Image size="80" resid="PG.Icon.Ask.80" />
-                  </Icon>
-                  <Action xsi:type="ExecuteFunction">
-                    <FunctionName>launchAsk</FunctionName>
-                  </Action>
-                </Control>
-              </Group>
-              <Label resid="PG.TabLabel" />
-            </CustomTab>
-          </ExtensionPoint>
-        </DesktopFormFactor>
-      </Host>
-    </Hosts>
-    <Resources>
-      <bt:Images>
-        <bt:Image id="PG.Icon.16" DefaultValue="https://script-lab.azureedge.net/assets/images/icon-16.png" />
-        <bt:Image id="PG.Icon.32" DefaultValue="https://script-lab.azureedge.net/assets/images/icon-32.png" />
-        <bt:Image id="PG.Icon.80" DefaultValue="https://script-lab.azureedge.net/assets/images/icon-80.png" />
-        <bt:Image id="PG.Icon.Code.16" DefaultValue="https://script-lab.azureedge.net/assets/images/code-16.png" />
-        <bt:Image id="PG.Icon.Code.32" DefaultValue="https://script-lab.azureedge.net/assets/images/code-32.png" />
-        <bt:Image id="PG.Icon.Code.80" DefaultValue="https://script-lab.azureedge.net/assets/images/code-80.png" />
-        <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab.azureedge.net/assets/images/run-16.png" />
-        <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab.azureedge.net/assets/images/run-32.png" />
-        <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab.azureedge.net/assets/images/run-80.png" />
-        <bt:Image id="PG.Icon.Tutorial.16" DefaultValue="https://script-lab.azureedge.net/assets/images/tutorial-16.png" />
-        <bt:Image id="PG.Icon.Tutorial.32" DefaultValue="https://script-lab.azureedge.net/assets/images/tutorial-32.png" />
-        <bt:Image id="PG.Icon.Tutorial.80" DefaultValue="https://script-lab.azureedge.net/assets/images/tutorial-80.png" />
-        <bt:Image id="PG.Icon.Help.16" DefaultValue="https://script-lab.azureedge.net/assets/images/help-16.png" />
-        <bt:Image id="PG.Icon.Help.32" DefaultValue="https://script-lab.azureedge.net/assets/images/help-32.png" />
-        <bt:Image id="PG.Icon.Help.80" DefaultValue="https://script-lab.azureedge.net/assets/images/help-80.png" />
-        <bt:Image id="PG.Icon.ApiDocs.16" DefaultValue="https://script-lab.azureedge.net/assets/images/docs-16.png" />
-        <bt:Image id="PG.Icon.ApiDocs.32" DefaultValue="https://script-lab.azureedge.net/assets/images/docs-32.png" />
-        <bt:Image id="PG.Icon.ApiDocs.80" DefaultValue="https://script-lab.azureedge.net/assets/images/docs-80.png" />
-        <bt:Image id="PG.Icon.Ask.16" DefaultValue="https://script-lab.azureedge.net/assets/images/ask-16.png" />
-        <bt:Image id="PG.Icon.Ask.32" DefaultValue="https://script-lab.azureedge.net/assets/images/ask-32.png" />
-        <bt:Image id="PG.Icon.Ask.80" DefaultValue="https://script-lab.azureedge.net/assets/images/ask-80.png" />
-      </bt:Images>
-      <bt:Urls>
-        <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab.azureedge.net/run.html" />
-        <bt:Url id="PG.Functions.Url" DefaultValue="https://script-lab.azureedge.net/functions.html" />
-      </bt:Urls>
-      <bt:ShortStrings>
-        <bt:String id="PG.TabLabel" DefaultValue="Script Lab" />
-        <bt:String id="PG.GroupLabel" DefaultValue="Script" />
-        <bt:String id="PG.AboutGroupLabel" DefaultValue="About Script Lab">
-          <bt:Override Locale="de-de" Value="Über Script Lab"/>
-          <bt:Override Locale="de-ch" Value="Über Script Lab"/>
-          <bt:Override Locale="de-at" Value="Über Script Lab"/>
-          <bt:Override Locale="es-ar" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-bo" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-cl" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-co" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-cr" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-do" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-ec" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-sv" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-gt" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-hn" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-mx" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-ni" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-pa" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-py" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-pe" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-pr" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-es" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-uy" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="es-mx" Value="Acerca de Script Lab"/>
-          <bt:Override Locale="zh-cn" Value="关于Script Lab"/>
-        </bt:String>
-        <bt:String id="PG.ApiGroupLabel" DefaultValue="About the APIs">
-          <bt:Override Locale="de-de" Value="Über die APIs"/>
-          <bt:Override Locale="de-ch" Value="Über die APIs"/>
-          <bt:Override Locale="de-at" Value="Über die APIs"/>
-          <bt:Override Locale="es-ar" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-bo" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-cl" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-co" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-cr" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-do" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-ec" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-sv" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-gt" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-hn" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-mx" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-ni" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-pa" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-py" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-pe" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-pr" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-es" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-uy" Value="Acerca de las APIs"/>
-          <bt:Override Locale="es-mx" Value="Acerca de las APIs"/>
-          <bt:Override Locale="zh-cn" Value="关于APIs"/>
-        </bt:String>
-        <bt:String id="PG.CodeCommand.Label" DefaultValue="Code">
-          <bt:Override Locale="zh-cn" Value="代码"/>
-        </bt:String>
-        <bt:String id="PG.CodeCommand.Title" DefaultValue="Code">
-          <bt:Override Locale="zh-cn" Value="代码"/>
-        </bt:String>
-        <bt:String id="PG.CodeCommand.TipTitle" DefaultValue="Create or edit code snippets">
-          <bt:Override Locale="de-de" Value="Erstellen oder Editieren von Code-Schnipseln"/>
-          <bt:Override Locale="de-ch" Value="Erstellen oder Editieren von Code-Schnipseln"/>
-          <bt:Override Locale="de-at" Value="Erstellen oder Editieren von Code-Schnipseln"/>
-          <bt:Override Locale="es-ar" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-bo" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-cl" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-co" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-cr" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-do" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-ec" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-sv" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-gt" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-hn" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-mx" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-ni" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-pa" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-py" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-pe" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-pr" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-es" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-uy" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="es-mx" Value="Crea o edita fragmentos de código"/>
-          <bt:Override Locale="zh-cn" Value="创建或编辑代码段"/>
-        </bt:String>
-        <bt:String id="PG.RunCommand.Label" DefaultValue="Run">
-          <bt:Override Locale="de-de" Value="Ausführen"/>
-          <bt:Override Locale="de-ch" Value="Ausführen"/>
-          <bt:Override Locale="de-at" Value="Ausführen"/>
-          <bt:Override Locale="es-ar" Value="Ejecutar"/>
-          <bt:Override Locale="es-bo" Value="Ejecutar"/>
-          <bt:Override Locale="es-cl" Value="Ejecutar"/>
-          <bt:Override Locale="es-co" Value="Ejecutar"/>
-          <bt:Override Locale="es-cr" Value="Ejecutar"/>
-          <bt:Override Locale="es-do" Value="Ejecutar"/>
-          <bt:Override Locale="es-ec" Value="Ejecutar"/>
-          <bt:Override Locale="es-sv" Value="Ejecutar"/>
-          <bt:Override Locale="es-gt" Value="Ejecutar"/>
-          <bt:Override Locale="es-hn" Value="Ejecutar"/>
-          <bt:Override Locale="es-mx" Value="Ejecutar"/>
-          <bt:Override Locale="es-ni" Value="Ejecutar"/>
-          <bt:Override Locale="es-pa" Value="Ejecutar"/>
-          <bt:Override Locale="es-py" Value="Ejecutar"/>
-          <bt:Override Locale="es-pe" Value="Ejecutar"/>
-          <bt:Override Locale="es-pr" Value="Ejecutar"/>
-          <bt:Override Locale="es-es" Value="Ejecutar"/>
-          <bt:Override Locale="es-uy" Value="Ejecutar"/>
-          <bt:Override Locale="es-mx" Value="Ejecutar"/>
-          <bt:Override Locale="zh-cn" Value="运行"/>
-        </bt:String>
-        <bt:String id="PG.RunCommand.Title" DefaultValue="Run">
-          <bt:Override Locale="de-de" Value="Ausführen"/>
-          <bt:Override Locale="de-ch" Value="Ausführen"/>
-          <bt:Override Locale="de-at" Value="Ausführen"/>
-          <bt:Override Locale="es-ar" Value="Ejecutar"/>
-          <bt:Override Locale="es-bo" Value="Ejecutar"/>
-          <bt:Override Locale="es-cl" Value="Ejecutar"/>
-          <bt:Override Locale="es-co" Value="Ejecutar"/>
-          <bt:Override Locale="es-cr" Value="Ejecutar"/>
-          <bt:Override Locale="es-do" Value="Ejecutar"/>
-          <bt:Override Locale="es-ec" Value="Ejecutar"/>
-          <bt:Override Locale="es-sv" Value="Ejecutar"/>
-          <bt:Override Locale="es-gt" Value="Ejecutar"/>
-          <bt:Override Locale="es-hn" Value="Ejecutar"/>
-          <bt:Override Locale="es-mx" Value="Ejecutar"/>
-          <bt:Override Locale="es-ni" Value="Ejecutar"/>
-          <bt:Override Locale="es-pa" Value="Ejecutar"/>
-          <bt:Override Locale="es-py" Value="Ejecutar"/>
-          <bt:Override Locale="es-pe" Value="Ejecutar"/>
-          <bt:Override Locale="es-pr" Value="Ejecutar"/>
-          <bt:Override Locale="es-es" Value="Ejecutar"/>
-          <bt:Override Locale="es-uy" Value="Ejecutar"/>
-          <bt:Override Locale="es-mx" Value="Ejecutar"/>
-          <bt:Override Locale="zh-cn" Value="运行"/>
-        </bt:String>
-        <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Run the code snippet">
-          <bt:Override Locale="de-de" Value="Code-Schnipsel ausführen"/>
-          <bt:Override Locale="de-ch" Value="Code-Schnipsel ausführen"/>
-          <bt:Override Locale="de-at" Value="Code-Schnipsel ausführen"/>
-          <bt:Override Locale="es-ar" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-bo" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-cl" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-co" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-cr" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-do" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-ec" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-sv" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-gt" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-hn" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-mx" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-ni" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-pa" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-py" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-pe" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-pr" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-es" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-uy" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="es-mx" Value="Ejecuta el fragmento de código"/>
-          <bt:Override Locale="zh-cn" Value="运行代码段"/>
-        </bt:String>
-        <bt:String id="PG.TutorialCommand.Label" DefaultValue="Tutorial">
-          <bt:Override Locale="zh-cn" Value="教程"/>
-        </bt:String>
-        <bt:String id="PG.TutorialCommand.TipTitle" DefaultValue="Script Lab tutorial">
-          <bt:Override Locale="de-de" Value="Tutorial zu Script Lab"/>
-          <bt:Override Locale="de-ch" Value="Tutorial zu Script Lab"/>
-          <bt:Override Locale="de-at" Value="Tutorial zu Script Lab"/>
-          <bt:Override Locale="es-ar" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-bo" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-cl" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-co" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-cr" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-do" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-ec" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-sv" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-gt" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-hn" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-mx" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-ni" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-pa" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-py" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-pe" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-pr" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-es" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-uy" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="es-mx" Value="Tutorial de Script Lab"/>
-          <bt:Override Locale="zh-cn" Value="Script Lab教程"/>
-        </bt:String>
-        <bt:String id="PG.HelpCommand.Label" DefaultValue="Help">
-          <bt:Override Locale="de-de" Value="Hilfe"/>
-          <bt:Override Locale="de-ch" Value="Hilfe"/>
-          <bt:Override Locale="de-at" Value="Hilfe"/>
-          <bt:Override Locale="es-ar" Value="Ayuda"/>
-          <bt:Override Locale="es-bo" Value="Ayuda"/>
-          <bt:Override Locale="es-cl" Value="Ayuda"/>
-          <bt:Override Locale="es-co" Value="Ayuda"/>
-          <bt:Override Locale="es-cr" Value="Ayuda"/>
-          <bt:Override Locale="es-do" Value="Ayuda"/>
-          <bt:Override Locale="es-ec" Value="Ayuda"/>
-          <bt:Override Locale="es-sv" Value="Ayuda"/>
-          <bt:Override Locale="es-gt" Value="Ayuda"/>
-          <bt:Override Locale="es-hn" Value="Ayuda"/>
-          <bt:Override Locale="es-mx" Value="Ayuda"/>
-          <bt:Override Locale="es-ni" Value="Ayuda"/>
-          <bt:Override Locale="es-pa" Value="Ayuda"/>
-          <bt:Override Locale="es-py" Value="Ayuda"/>
-          <bt:Override Locale="es-pe" Value="Ayuda"/>
-          <bt:Override Locale="es-pr" Value="Ayuda"/>
-          <bt:Override Locale="es-es" Value="Ayuda"/>
-          <bt:Override Locale="es-uy" Value="Ayuda"/>
-          <bt:Override Locale="es-mx" Value="Ayuda"/>
-          <bt:Override Locale="zh-cn" Value="帮助"/>
-        </bt:String>
-        <bt:String id="PG.HelpCommand.TipTitle" DefaultValue="Help for Script Lab">
-          <bt:Override Locale="de-de" Value="Hilfe zu Script Lab"/>
-          <bt:Override Locale="de-ch" Value="Hilfe zu Script Lab"/>
-          <bt:Override Locale="de-at" Value="Hilfe zu Script Lab"/>
-          <bt:Override Locale="es-ar" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-bo" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-cl" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-co" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-cr" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-do" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-ec" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-sv" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-gt" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-hn" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-mx" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-ni" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-pa" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-py" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-pe" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-pr" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-es" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-uy" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="es-mx" Value="Ayuda de Script Lab"/>
-          <bt:Override Locale="zh-cn" Value="Script Lab的帮助信息"/>
-        </bt:String>
-       <bt:String id="PG.ApiDocsCommand.Label" DefaultValue="Reference Docs">
-          <bt:Override Locale="de-de" Value="Dokumentation"/>
-          <bt:Override Locale="de-ch" Value="Dokumentation"/>
-          <bt:Override Locale="de-at" Value="Dokumentation"/>
-          <bt:Override Locale="es-ar" Value="Documentación"/>
-          <bt:Override Locale="es-bo" Value="Documentación"/>
-          <bt:Override Locale="es-cl" Value="Documentación"/>
-          <bt:Override Locale="es-co" Value="Documentación"/>
-          <bt:Override Locale="es-cr" Value="Documentación"/>
-          <bt:Override Locale="es-do" Value="Documentación"/>
-          <bt:Override Locale="es-ec" Value="Documentación"/>
-          <bt:Override Locale="es-sv" Value="Documentación"/>
-          <bt:Override Locale="es-gt" Value="Documentación"/>
-          <bt:Override Locale="es-hn" Value="Documentación"/>
-          <bt:Override Locale="es-mx" Value="Documentación"/>
-          <bt:Override Locale="es-ni" Value="Documentación"/>
-          <bt:Override Locale="es-pa" Value="Documentación"/>
-          <bt:Override Locale="es-py" Value="Documentación"/>
-          <bt:Override Locale="es-pe" Value="Documentación"/>
-          <bt:Override Locale="es-pr" Value="Documentación"/>
-          <bt:Override Locale="es-es" Value="Documentación"/>
-          <bt:Override Locale="es-uy" Value="Documentación"/>
-          <bt:Override Locale="es-mx" Value="Documentación"/>
-          <bt:Override Locale="zh-cn" Value="参考文档"/>
-        </bt:String>
-        <bt:String id="PG.ApiDocsCommand.TipTitle" DefaultValue="API Reference Documentation">
-          <bt:Override Locale="de-de" Value="API-Dokumentation"/>
-          <bt:Override Locale="de-ch" Value="API-Dokumentation"/>
-          <bt:Override Locale="de-at" Value="API-Dokumentation"/>
-          <bt:Override Locale="es-ar" Value="Documentación de la API"/>
-          <bt:Override Locale="es-bo" Value="Documentación de la API"/>
-          <bt:Override Locale="es-cl" Value="Documentación de la API"/>
-          <bt:Override Locale="es-co" Value="Documentación de la API"/>
-          <bt:Override Locale="es-cr" Value="Documentación de la API"/>
-          <bt:Override Locale="es-do" Value="Documentación de la API"/>
-          <bt:Override Locale="es-ec" Value="Documentación de la API"/>
-          <bt:Override Locale="es-sv" Value="Documentación de la API"/>
-          <bt:Override Locale="es-gt" Value="Documentación de la API"/>
-          <bt:Override Locale="es-hn" Value="Documentación de la API"/>
-          <bt:Override Locale="es-mx" Value="Documentación de la API"/>
-          <bt:Override Locale="es-ni" Value="Documentación de la API"/>
-          <bt:Override Locale="es-pa" Value="Documentación de la API"/>
-          <bt:Override Locale="es-py" Value="Documentación de la API"/>
-          <bt:Override Locale="es-pe" Value="Documentación de la API"/>
-          <bt:Override Locale="es-pr" Value="Documentación de la API"/>
-          <bt:Override Locale="es-es" Value="Documentación de la API"/>
-          <bt:Override Locale="es-uy" Value="Documentación de la API"/>
-          <bt:Override Locale="es-mx" Value="Documentación de la API"/>
-          <bt:Override Locale="zh-cn" Value="API参考文档"/>
-        </bt:String>
-        <bt:String id="PG.AskCommand.Label" DefaultValue="Ask the Community">
-          <bt:Override Locale="de-de" Value="Community"/>
-          <bt:Override Locale="de-ch" Value="Community"/>
-          <bt:Override Locale="de-at" Value="Community"/>
-          <bt:Override Locale="es-ar" Value="Comunidad"/>
-          <bt:Override Locale="es-bo" Value="Comunidad"/>
-          <bt:Override Locale="es-cl" Value="Comunidad"/>
-          <bt:Override Locale="es-co" Value="Comunidad"/>
-          <bt:Override Locale="es-cr" Value="Comunidad"/>
-          <bt:Override Locale="es-do" Value="Comunidad"/>
-          <bt:Override Locale="es-ec" Value="Comunidad"/>
-          <bt:Override Locale="es-sv" Value="Comunidad"/>
-          <bt:Override Locale="es-gt" Value="Comunidad"/>
-          <bt:Override Locale="es-hn" Value="Comunidad"/>
-          <bt:Override Locale="es-mx" Value="Comunidad"/>
-          <bt:Override Locale="es-ni" Value="Comunidad"/>
-          <bt:Override Locale="es-pa" Value="Comunidad"/>
-          <bt:Override Locale="es-py" Value="Comunidad"/>
-          <bt:Override Locale="es-pe" Value="Comunidad"/>
-          <bt:Override Locale="es-pr" Value="Comunidad"/>
-          <bt:Override Locale="es-es" Value="Comunidad"/>
-          <bt:Override Locale="es-uy" Value="Comunidad"/>
-          <bt:Override Locale="es-mx" Value="Comunidad"/>
-          <bt:Override Locale="zh-cn" Value="询问社区"/>
-        </bt:String>
-        <bt:String id="PG.AskCommand.TipTitle" DefaultValue="Get API help from the community">
-          <bt:Override Locale="de-de" Value="Unterstützung durch die Community"/>
-          <bt:Override Locale="de-ch" Value="Unterstützung durch die Community"/>
-          <bt:Override Locale="de-at" Value="Unterstützung durch die Community"/>
-          <bt:Override Locale="es-ar" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-bo" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-cl" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-co" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-cr" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-do" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-ec" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-sv" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-gt" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-hn" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-mx" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-ni" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-pa" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-py" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-pe" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-pr" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-es" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-uy" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="es-mx" Value="Obtén ayuda de nuestra comunidad"/>
-          <bt:Override Locale="zh-cn" Value="从社区获取API帮助"/>
-        </bt:String>
-        <bt:String id="PG.CFNamespace" DefaultValue="SCRIPTLAB" />
-      </bt:ShortStrings>
-      <bt:LongStrings>
-        <bt:String id="PG.CodeSupertip.Desc" DefaultValue="Opens the Script Lab code editor">
-          <bt:Override Locale="de-de" Value="Den Script Lab Code-Editor aufrufen."/>
-          <bt:Override Locale="de-ch" Value="Den Script Lab Code-Editor aufrufen."/>
-          <bt:Override Locale="de-at" Value="Den Script Lab Code-Editor aufrufen."/>
-          <bt:Override Locale="es-ar" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-bo" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-cl" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-co" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-cr" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-do" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-ec" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-sv" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-gt" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-hn" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-mx" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-ni" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-pa" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-py" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-pe" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-pr" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-es" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-uy" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="es-mx" Value="Abre el editor de código de Script Lab."/>
-          <bt:Override Locale="zh-cn" Value="打开Script Lab代码编辑器"/>
-        </bt:String>
-        <bt:String id="PG.CFSupertip.Desc" DefaultValue="Launch the Custom Functions dashboard">
-          <bt:Override Locale="de-de" Value="Den Aufgabenbereich zu den benutzerdefinierten Funktionen aufrufen."/>
-          <bt:Override Locale="de-ch" Value="Den Aufgabenbereich zu den benutzerdefinierten Funktionen aufrufen."/>
-          <bt:Override Locale="de-at" Value="Den Aufgabenbereich zu den benutzerdefinierten Funktionen aufrufen."/>
-        </bt:String>
-        <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet">
-          <bt:Override Locale="de-de" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
-          <bt:Override Locale="de-ch" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
-          <bt:Override Locale="de-at" Value="Den Aufgabenbereich zum Ausführen eines Code-Schnipsels aufrufen."/>
-          <bt:Override Locale="es-ar" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-bo" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-cl" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-co" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-cr" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-do" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-ec" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-sv" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-gt" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-hn" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-mx" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-ni" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-pa" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-py" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-pe" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-pr" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-es" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-uy" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="es-mx" Value="Abre el panel que ejecuta el fragmento de código actual."/>
-          <bt:Override Locale="zh-cn" Value="打开运行当前代码段的任务窗格"/>
-        </bt:String>
-        <bt:String id="PG.TutorialCommand.Desc" DefaultValue="Launches a quick Script Lab tutorial">
-          <bt:Override Locale="de-de" Value="Ein Tutorial zu Script Lab aufrufen."/>
-          <bt:Override Locale="de-ch" Value="Ein Tutorial zu Script Lab aufrufen."/>
-          <bt:Override Locale="de-at" Value="Ein Tutorial zu Script Lab aufrufen."/>
-          <bt:Override Locale="es-ar" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-bo" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-cl" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-co" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-cr" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-do" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-ec" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-sv" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-gt" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-hn" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-mx" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-ni" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-pa" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-py" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-pe" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-pr" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-es" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-uy" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="es-mx" Value="Abre un breve tutorial de Script Lab."/>
-          <bt:Override Locale="zh-cn" Value="启动Script Lab快速教程"/>
-        </bt:String>
-        <bt:String id="PG.HelpCommand.Desc" DefaultValue="Launches documentation on using Script Lab">
-          <bt:Override Locale="de-de" Value="Die Dokumentation zu Script Lab aufrufen."/>
-          <bt:Override Locale="de-ch" Value="Die Dokumentation zu Script Lab aufrufen."/>
-          <bt:Override Locale="de-at" Value="Die Dokumentation zu Script Lab aufrufen."/>
-          <bt:Override Locale="es-ar" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-bo" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-cl" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-co" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-cr" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-do" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-ec" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-sv" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-gt" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-hn" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-mx" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-ni" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-pa" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-py" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-pe" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-pr" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-es" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-uy" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="es-mx" Value="Abre la documentación acerca del uso de Script Lab."/>
-          <bt:Override Locale="zh-cn" Value="启动Script Lab文档"/>
-        </bt:String>
-        <bt:String id="PG.ApiDocsCommand.Desc" DefaultValue="Opens the API documentation for the Office application that you are running">
-          <bt:Override Locale="de-de" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
-          <bt:Override Locale="de-ch" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
-          <bt:Override Locale="de-at" Value="Die JavaScript API-Dokumentation (Englisch) für die aktuelle Office-Anwendung aufrufen."/>
-          <bt:Override Locale="es-ar" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-bo" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-cl" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-co" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-cr" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-do" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-ec" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-sv" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-gt" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-hn" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-mx" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-ni" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-pa" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-py" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-pe" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-pr" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-es" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-uy" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="es-mx" Value="Abre la documentación del API asociado con la aplicación de Office que estas corriendo."/>
-          <bt:Override Locale="zh-cn" Value="打开正在运行的Office应用程序的API文档"/>
-        </bt:String>
-        <bt:String id="PG.AskCommand.Desc" DefaultValue="Launches a community forum for questions about the Office JavaScript APIs">
-          <bt:Override Locale="de-de" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
-          <bt:Override Locale="de-ch" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
-          <bt:Override Locale="de-at" Value="Ein Community-Forum (Englisch) für Fragen und Antworten rund um das Office JavaScript API aufrufen."/>
-          <bt:Override Locale="es-ar" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-bo" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-cl" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-co" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-cr" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-do" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-ec" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-sv" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-gt" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-hn" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-mx" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-ni" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-pa" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-py" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-pe" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-pr" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-es" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-uy" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="es-mx" Value="Abre un foro dentro de nuestra comunidad para preguntas asociadas con la JavaScript API de Office."/>
-          <bt:Override Locale="zh-cn" Value="启动社区论坛来讨论有关Office JavaScript API的问题"/>
-        </bt:String>
-        <bt:String id="PG.Description" DefaultValue="Code, run, and share your Add-in snippets directly from Office.">
-          <bt:Override Locale="de-de" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
-          <bt:Override Locale="de-ch" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
-          <bt:Override Locale="de-at" Value="Code-Schnipsel für Add-Ins direkt aus Office heraus erstellen, ausführen und teilen."/>
-          <bt:Override Locale="es-ar" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-bo" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-cl" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-co" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-cr" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-do" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-ec" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-sv" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-gt" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-hn" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-mx" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-ni" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-pa" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-py" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-pe" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-pr" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-es" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-uy" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="es-mx" Value="Codifica, ejecuta y comparte tus fragmentos de codigo directamente desde Office."/>
-          <bt:Override Locale="zh-cn" Value="直接从Office中编码、运行和共享代码段。"/>
-        </bt:String>
-      </bt:LongStrings>
-    </Resources>
+            <Requirements>
+                <bt:Sets DefaultMinVersion="1.3">
+                    <bt:Set Name="Mailbox"/>
+                </bt:Sets>
+            </Requirements>
+            <Hosts>
+                <Host xsi:type="MailHost">
+                    <DesktopFormFactor>
+                        <SupportsSharedFolders>true</SupportsSharedFolders>
+                        <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
+                            <OfficeTab id="TabDefault">
+                                <Group id="PG.PlayGroup.AA">
+                                    <Label resid="PG.GroupLabel"/>
+                                    <Control xsi:type="Button" id="PG.RunCommand.AA">
+                                        <Label resid="PG.RunCommand.Label" />
+                                        <Supertip>
+                                            <Title resid="PG.RunCommand.TipTitle" />
+                                            <Description resid="PG.RunSupertip.Desc" />
+                                        </Supertip>
+                                        <Icon>
+                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
+                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
+                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
+                                        </Icon>
+                                        <Action xsi:type="ShowTaskpane">
+                                            <SourceLocation resid="PG.Run.Url" />
+                                            <SupportsPinning>true</SupportsPinning>
+                                        </Action>
+                                    </Control>
+                                </Group>
+                            </OfficeTab>
+                        </ExtensionPoint>
+                        <ExtensionPoint xsi:type="MessageReadCommandSurface">
+                            <OfficeTab id="TabDefault">
+                                <Group id="PG.PlayGroup.MR">
+                                    <Label resid="PG.GroupLabel"/>
+                                    <Control xsi:type="Button" id="PG.RunCommand.MR">
+                                        <Label resid="PG.RunCommand.Label" />
+                                        <Supertip>
+                                            <Title resid="PG.RunCommand.TipTitle" />
+                                            <Description resid="PG.RunSupertip.Desc" />
+                                        </Supertip>
+                                        <Icon>
+                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
+                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
+                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
+                                        </Icon>
+                                        <Action xsi:type="ShowTaskpane">
+                                            <SourceLocation resid="PG.Run.Url" />
+                                            <SupportsPinning>true</SupportsPinning>
+                                        </Action>
+                                    </Control>
+                                </Group>
+                            </OfficeTab>
+                        </ExtensionPoint>
+                        <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+                            <OfficeTab id="TabDefault">
+                                <Group id="PG.PlayGroup.AO">
+                                    <Label resid="PG.GroupLabel"/>
+                                    <Control xsi:type="Button" id="PG.RunCommand.AO">
+                                        <Label resid="PG.RunCommand.Label" />
+                                        <Supertip>
+                                            <Title resid="PG.RunCommand.TipTitle" />
+                                            <Description resid="PG.RunSupertip.Desc" />
+                                        </Supertip>
+                                        <Icon>
+                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
+                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
+                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
+                                        </Icon>
+                                        <Action xsi:type="ShowTaskpane">
+                                            <SourceLocation resid="PG.Run.Url" />
+                                            <SupportsPinning>true</SupportsPinning>
+                                        </Action>
+                                    </Control>
+                                </Group>
+                            </OfficeTab>
+                        </ExtensionPoint>
+                        <ExtensionPoint xsi:type="MessageComposeCommandSurface">
+                            <OfficeTab id="TabDefault">
+                                <Group id="PG.PlayGroup.MC">
+                                    <Label resid="PG.GroupLabel"/>
+                                    <Control xsi:type="Button" id="PG.RunCommand.MC">
+                                        <Label resid="PG.RunCommand.Label" />
+                                        <Supertip>
+                                            <Title resid="PG.RunCommand.TipTitle" />
+                                            <Description resid="PG.RunSupertip.Desc" />
+                                        </Supertip>
+                                        <Icon>
+                                            <bt:Image size="16" resid="PG.Icon.Run.16" />
+                                            <bt:Image size="32" resid="PG.Icon.Run.32" />
+                                            <bt:Image size="80" resid="PG.Icon.Run.80" />
+                                        </Icon>
+                                        <Action xsi:type="ShowTaskpane">
+                                            <SourceLocation resid="PG.Run.Url" />
+                                            <SupportsPinning>true</SupportsPinning>
+                                        </Action>
+                                    </Control>
+                                </Group>
+                            </OfficeTab>
+                        </ExtensionPoint>
+                        <ExtensionPoint xsi:type="DetectedEntity">
+                            <Label resid="PG.RunCommand.Label" />
+                            <SourceLocation resid="PG.Run.Url" />
+                            <Rule xsi:type="RuleCollection" Mode="Or">
+                                <Rule xsi:type="ItemHasKnownEntity" FilterName="sampleFilterName" RegExFilter="Way" EntityType="Address" Highlight="all" />
+                                <Rule xsi:type="ItemHasRegularExpressionMatch" RegExName="sampleRegexName" RegExValue="ScriptLab" PropertyName="BodyAsPlaintext" IgnoreCase="true" Highlight="All" />
+                            </Rule>
+                        </ExtensionPoint>     
+                    </DesktopFormFactor>
+                </Host>
+            </Hosts>
+            <Resources>
+                <bt:Images>
+                    <bt:Image id="PG.Icon.Run.16" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-16.png" />
+                    <bt:Image id="PG.Icon.Run.32" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-32.png" />
+                    <bt:Image id="PG.Icon.Run.80" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/assets/images/icon-80.png" />
+                </bt:Images>
+                <bt:Urls>
+                    <bt:Url id="PG.Run.Url" DefaultValue="https://script-lab-react-alpha.azurewebsites.net/run.html" />
+                </bt:Urls>
+                <bt:ShortStrings>
+                    <bt:String id="PG.GroupLabel" DefaultValue="Script Lab [ALPHA]" />
+                    <bt:String id="PG.RunCommand.Label" DefaultValue="Script Lab"></bt:String>
+                    <bt:String id="PG.RunCommand.Title" DefaultValue="Script Lab"></bt:String>
+                    <bt:String id="PG.RunCommand.TipTitle" DefaultValue="Open Script Lab for Outlook"></bt:String>
+                </bt:ShortStrings>
+                <bt:LongStrings>
+                    <bt:String id="PG.RunSupertip.Desc" DefaultValue="Opens a task pane that runs the current snippet"></bt:String>
+                </bt:LongStrings>
+            </Resources>
         </VersionOverrides>
     </VersionOverrides>
 </OfficeApp>

--- a/packages/common/src/utilities/popout.control.ts
+++ b/packages/common/src/utilities/popout.control.ts
@@ -64,33 +64,6 @@ export function openPopoutCodeEditor(
     },
   );
 }
-
-export function openPopoutTutorial(
-  tutorialUrl: string,
-  { onSuccess }: { onSuccess: () => void } = { onSuccess: () => {} },
-) {
-  Office.context.ui.displayDialogAsync(
-    tutorialUrl,
-    {
-      height: 60,
-      width: 60,
-      promptBeforeOpen: false,
-    },
-    (result: Office.AsyncResult<any>) => {
-      if (result.status === Office.AsyncResultStatus.Succeeded) {
-        onSuccess();
-      } else {
-        console.error(result);
-        invokeGlobalErrorHandler(
-          new ScriptLabError(
-            'Could not open a standalone tutorial window: ' + result.error.message,
-          ),
-        );
-      }
-    },
-  );
-}
-
 export function isPoppedOut(): boolean {
   const params: { [key: string]: any } = queryString.parse(window.location.search);
   return params[IS_DIALOG_QUERY_PARAMETER] ? true : false;

--- a/packages/editor/src/pages/AddinCommands/setup.ts
+++ b/packages/editor/src/pages/AddinCommands/setup.ts
@@ -117,11 +117,11 @@ function launchDialogNavigation(
   launchInDialog(
     // Checks to see if the host is Outlook Online and the url is the codeUrl or editorUrl
     // and sets url appropriately
-    isOutlookOnlineUrl(url)
+    isOutlookOnlinePopoutUrl(url)
       ? url
       : `${window.location.origin}/#/external-page?destination=${encodeURIComponent(
-          url,
-        )}`,
+        url,
+      )}`,
     event,
     options,
     onSuccessCallback,
@@ -138,7 +138,7 @@ function launchInStandaloneWindow(url: string, event: any): void {
     event,
     // Checks to see if the host is Outlook Online and the url is the codeUrl or editorUrl
     // and sets options appropriately
-    isOutlookOnlineUrl(url)
+    isOutlookOnlinePopoutUrl(url)
       ? { displayInIframe: false, width: 60, height: 60 }
       : { displayInIframe: true, width: 30, height: 30 },
     (dialog: Office.Dialog) => {
@@ -161,6 +161,6 @@ function isOutlookOnline(): boolean {
   );
 }
 
-function isOutlookOnlineUrl(url: string): boolean {
-  return isOutlookOnline && (url === codeUrl || url === tutorialUrl);
+function isOutlookOnlinePopoutUrl(url: string): boolean {
+  return isOutlookOnline() && (url === codeUrl || url === tutorialUrl);
 }

--- a/packages/editor/src/pages/AddinCommands/setup.ts
+++ b/packages/editor/src/pages/AddinCommands/setup.ts
@@ -120,8 +120,8 @@ function launchDialogNavigation(
     isOutlookOnlinePopoutUrl(url)
       ? url
       : `${window.location.origin}/#/external-page?destination=${encodeURIComponent(
-        url,
-      )}`,
+          url,
+        )}`,
     event,
     options,
     onSuccessCallback,

--- a/packages/editor/src/pages/AddinCommands/setup.ts
+++ b/packages/editor/src/pages/AddinCommands/setup.ts
@@ -1,6 +1,6 @@
 import { Utilities, HostType, PlatformType } from '@microsoft/office-js-helpers';
 import safeExternalUrls from 'common/lib/safe.external.urls';
-import * as popoutControl from 'common/lib/utilities/popout.control';
+import { hideSplashScreen } from 'common/lib/utilities/splash.screen';
 
 export default function setup() {
   // SUPER IMPORTANT NOTE:  The add-in commands code doesn't do a redirect to localhost
@@ -9,8 +9,9 @@ export default function setup() {
   //   If you need to change this logic and test locally, sideload the localhost version.
 
   registerCommand('launchCode', event => {
-    if (shouldOpenPopout()) {
-      return popoutControl.openPopoutCodeEditor();
+    if (isOutlookOnline()) {
+      hideSplashScreen();
+      return launchInStandaloneWindow(codeUrl, event);
     } else {
       return launchInDialog(codeUrl, event, {
         width: 75,
@@ -21,8 +22,9 @@ export default function setup() {
   });
 
   registerCommand('launchTutorial', event => {
-    if (shouldOpenPopout()) {
-      return popoutControl.openPopoutTutorial(tutorialUrl);
+    if (isOutlookOnline()) {
+      hideSplashScreen();
+      return launchInStandaloneWindow(tutorialUrl, event);
     } else {
       return launchInDialog(tutorialUrl, event, { width: 35, height: 45 });
     }
@@ -113,7 +115,13 @@ function launchDialogNavigation(
   onSuccessCallback?: (dialog: Office.Dialog) => void,
 ): void {
   launchInDialog(
-    `${window.location.origin}/#/external-page?destination=${encodeURIComponent(url)}`,
+    // Checks to see if the host is Outlook Online and the url is the codeUrl or editorUrl
+    // and sets url appropriately
+    isOutlookOnlineUrl(url)
+      ? url
+      : `${window.location.origin}/#/external-page?destination=${encodeURIComponent(
+          url,
+        )}`,
     event,
     options,
     onSuccessCallback,
@@ -128,7 +136,11 @@ function launchInStandaloneWindow(url: string, event: any): void {
   launchDialogNavigation(
     url,
     event,
-    { displayInIframe: true, width: 30, height: 30 },
+    // Checks to see if the host is Outlook Online and the url is the codeUrl or editorUrl
+    // and sets options appropriately
+    isOutlookOnlineUrl(url)
+      ? { displayInIframe: false, width: 60, height: 60 }
+      : { displayInIframe: true, width: 30, height: 30 },
     (dialog: Office.Dialog) => {
       dialog.addEventHandler(
         Office.EventType.DialogMessageReceived,
@@ -142,9 +154,13 @@ function launchInStandaloneWindow(url: string, event: any): void {
   );
 }
 
-function shouldOpenPopout(): boolean {
+function isOutlookOnline(): boolean {
   return (
     Utilities.host === HostType.OUTLOOK &&
     Utilities.platform == PlatformType.OFFICE_ONLINE
   );
+}
+
+function isOutlookOnlineUrl(url: string): boolean {
+  return isOutlookOnline && (url === codeUrl || url === tutorialUrl);
 }


### PR DESCRIPTION
- Changes in Outlook manifests remove custom tabs because they aren't yet supported on Mac in Prod.  Once they are we can revert the manifests back to use custom tabs.
- Added fix to deal with pop-up blockers by having the Editor and Tutorial display dialogs informing users that a new dialog is opening and asking for their approval
  
- Tested against Windows and Mac
- Tested against Edge, Chrome and Safari.

Caveats:
- First on Mac, a nice little command group is not created on as it is for Windows. 
![Mac-Outlook](https://user-images.githubusercontent.com/38081557/82615756-09c13e80-9b80-11ea-815c-82a5ffe80f7d.jpeg)
- Second, on Mac Safari, you need to disable cross-origin restrictions in order for the Editor to be able to communicate with the Runner.

