### PR TITLE
Use the latest LTS NodeJS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 10
+  - lts/*
 
 branches:
   only:


### PR DESCRIPTION
Updates Travis to use the latest LTS NodeJS version, rather than hardcoded to 10.