### PR TITLE
Update react

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,7 +16,7 @@
     "loglevel-plugin-prefix": "^0.8.4",
     "office-ui-fabric-react": "^6.211.6",
     "query-string": "5.1.1",
-    "react": "^16.5.0",
+    "react": "^17.0.2",
     "react-dom": "^16.5.0",
     "react-inspector": "^2.3.1",
     "react-router": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11292,6 +11292,14 @@ react@^16.5.0, react@^16.7.0-alpha.2:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"


### PR DESCRIPTION
Our version of react is pretty out of date, so this pulls it up to the most recent version 17.0.2.
I did some manual testing and so far haven't noticed any issues related to updating react, but we should let this PR sit in alpha for a while to perform more thorough testing.