### PR TITLE
Remove devDependency on copy-webpack-plugin

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@types/express": "^4.16.0",
     "@types/node": "^10.10.3",
-    "copy-webpack-plugin": "^4.5.2",
     "nodemon": "^1.18.3",
     "shelljs": "^0.8.2",
     "ts-loader": "^5.2.0",

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -1,6 +1,5 @@
 const webpack = require('webpack');
 const path = require('path');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
   entry: './src/index.ts',
@@ -15,5 +14,4 @@ module.exports = {
   module: {
     rules: [{ test: /\.ts$/, loader: 'ts-loader' }],
   },
-  plugins: [new CopyWebpackPlugin(['web.config'])],
 };


### PR DESCRIPTION
This dependency doesn't seem to be used anymore, so we're pulling it out. 