### PR TITLE
Drop IE Support 

### DIFF
--- a/packages/editor/public/index.html
+++ b/packages/editor/public/index.html
@@ -44,6 +44,33 @@
         overflow: hidden;
       }
 
+      #ieErrorWrapper {
+        position: absolute;
+        z-index: 10000001;
+        color: #212121;
+        background: white;
+        height: 100%;
+        width: 100%;
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -webkit-box-align: center;
+        -ms-flex-align: center;
+        align-items: center;
+        -webkit-box-pack: center;
+        -ms-flex-pack: center;
+        justify-content: center;
+      }
+
+      #ieErrorText {
+        width: 80%;
+        text-align: center;
+      }
+
       #loading {
         position: absolute;
         z-index: 10000001;
@@ -198,6 +225,39 @@
       </div>
     </div>
 
+    <div id="ieErrorWrapper" style="visibility: hidden;">
+      <div id="ieErrorText">
+        <p>
+          Script Lab no longer supports the Internet Explorer 11 browser or embedded
+          browser control. Please upgrade to a
+          <a
+            href="https://docs.microsoft.com/en-us/office/dev/add-ins/concepts/browsers-used-by-office-web-add-ins"
+            target="_blank"
+            >supported version</a
+          >
+          of Microsoft 365 or open Office on the web in a
+          <a
+            href="https://docs.microsoft.com/en-us/office/dev/add-ins/concepts/browsers-used-by-office-web-add-ins"
+            target="_blank"
+            >supported browser</a
+          >.
+        </p>
+      </div>
+    </div>
+
     <div id="root"></div>
   </body>
+
+  <script>
+    var isIE = window.ActiveXObject !== undefined;
+
+    if (isIE) {
+      url = window.location;
+      document.getElementById('ieErrorWrapper').style.visibility = 'visible';
+      document.getElementById('loading').style.visibility = 'hidden';
+    } else {
+      document.getElementById('ieErrorWrapper').style.visibility = 'hidden';
+      document.getElementById('loading').style.visibility = 'visible';
+    }
+  </script>
 </html>

--- a/packages/editor/public/index.html
+++ b/packages/editor/public/index.html
@@ -251,6 +251,8 @@
   <script>
     var isIE = window.ActiveXObject !== undefined;
 
+    // If currently in IE, replace the loading indicator with the ieErrorWrapper
+    // which directs users to update their version of Office, or move to another browser
     if (isIE) {
       url = window.location;
       document.getElementById('ieErrorWrapper').style.visibility = 'visible';


### PR DESCRIPTION
This adds an "IE not supported" messenger any time that the addin is loaded in an IE browser. 

![image](https://user-images.githubusercontent.com/10774982/125003346-e3709380-e00b-11eb-85c6-50dc7943cf99.png)
