### PR TITLE
Deploy script changed for condition check to see if the change is a PR

### DIFF
--- a/scripts/deploy/index.ts
+++ b/scripts/deploy/index.ts
@@ -40,7 +40,7 @@ if (!BRANCH) {
    And in any case, pull requests don't get secret variables like username or password
    passed to them by the CI tools, so the deploy would abort at any rate).
  */
-if (PULL_REQUEST !== 'false') {
+if (PULL_REQUEST !== 'False') {
   exit('Skipping deploy for pull requests');
 }
 


### PR DESCRIPTION
Travis would have this variable to know if the change is a PR set as 'false' but azure pipelines uses 'False'