### PR TITLE
Common package built to a lib folder and not a build folder so it was not recognized by the deployment pipeline

### DIFF
--- a/package-pipeline-template.yml
+++ b/package-pipeline-template.yml
@@ -62,7 +62,7 @@ steps:
       ProjectDirectory: '${{ parameters.PackageDirectory }}'
       Arguments: 'citest'
 
-  - script: cd ${{ parameters.PackageDirectory }} && yarn build
+  - script: cd ${{ parameters.PackageDirectory }} && yarn cibuild
     displayName: 'Build'
     env:
       COMMIT_MESSAGE: '$(Build.SourceVersionMessage)'

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,9 +25,9 @@
     "typescript": "^3.2.4"
   },
   "scripts": {
-    "postinstall": "yarn build",
-    "build": "yarn build:package --outDir build",
-    "build:package": "tsc",
+    "postinstall": "yarn build:package",
+    "build": "yarn build:package",
+    "build:package": "tsc --outDir build",
     "start": "tsc --watch",
     "lint": "tslint \"src/**/*.ts?(x)\"",
     "test": "jest --env=jsdom",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,8 +25,8 @@
     "typescript": "^3.2.4"
   },
   "scripts": {
-    "postinstall": "yarn build:package",
-    "build": "yarn build:package",
+    "postinstall": "yarn build",
+    "build": "yarn build:package --outDir build",
     "build:package": "tsc",
     "start": "tsc --watch",
     "lint": "tslint \"src/**/*.ts?(x)\"",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "postinstall": "yarn build:package",
     "build": "yarn build:package",
-    "build:package": "tsc --outDir build",
+    "build:package": "tsc",
+    "cibuild": "yarn build --outDir build",
     "start": "tsc --watch",
     "lint": "tslint \"src/**/*.ts?(x)\"",
     "test": "jest --env=jsdom",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -40,6 +40,7 @@
     "start": "react-scripts start",
     "lint": "tslint \"src/**/*.ts?(x)\"",
     "build": "node scripts/build.js",
+    "cibuild": "yarn build",
     "test": "jest --env=jsdom --verbose",
     "citest": "yarn test",
     "test:watch": "jest --env=jsdom --verbose --watch",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -22,6 +22,7 @@
     "postinstall": "ts-node --project ../../scripts/tsconfig.json scripts/postinstall.ts",
     "start": "react-scripts start",
     "build": "export CI=false&&react-scripts build",
+    "cibuild": "yarn build",
     "test": "react-scripts test --env=jsdom",
     "citest": "CI=true react-scripts test --env=jsdom",
     "lint": "tslint \"src/**/*.ts?(x)\""

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,6 +5,7 @@
     "start": "nodemon -e ts -w ./src -x npm run start:serve",
     "start:serve": "ts-node --files --inspect -- src/index.ts",
     "build": "webpack-cli --mode production",
+    "cibuild": "yarn build",
     "lint": "tslint \"src/**/*.ts?(x)\"",
     "test": "echo 'no tests'",
     "citest": "yarn test"

--- a/scripts/deploy/index.ts
+++ b/scripts/deploy/index.ts
@@ -32,6 +32,7 @@ if (!BRANCH) {
   exit(
     'Expecting to run the deploy script from within Azure-Pipelines ' +
       '(or at least, with all environmental variables set up). Exiting.',
+    true,
   );
 }
 
@@ -56,7 +57,7 @@ if (!DEPLOYMENT_SLOTS_DICTIONARY[BRANCH]) {
 
 const BUILD_DIRECTORY = path.join(PACKAGE_LOCATION, 'build');
 if (!shell.test('-d', BUILD_DIRECTORY)) {
-  exit('ERROR: No build directory found!');
+  exit('ERROR: No build directory found!', true);
 }
 
 (async () => {


### PR DESCRIPTION
This seems to be an issue that was happening in the travis-CI recently as well
![image](https://user-images.githubusercontent.com/25057940/126813909-d5e3f604-45fb-4527-b1e2-c12bfde14b9c.png)
When the common package was built, it would build into a _lib_ folder. And when the deployment script runs it is looking for the build files on _packages/common/build_.

After this change, the common package should also be deployed to azure

Even if the deployment pipeline would fail because it could not find the build folder, it would still be marked as successful and the travis build would pass. (Same thing happening now with azure pipelines)
![image](https://user-images.githubusercontent.com/25057940/126815159-bdfdd3a7-9314-4bb1-bb52-384d61917a6f.png)

Now when the build folder is not found, we will exit with an error which should mark the pipeline as failed