### PR TITLE
Add aria labels for main controls

### DIFF
--- a/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
@@ -31,7 +31,7 @@ class GalleryList extends Component<IProps, IState> {
         <FocusZone>
           <TitleBar>
             <Title>{title}</Title>
-            <ArrowWrapper onClick={this.toggleExpansion} data-is-focusable={true}>
+            <ArrowWrapper role={"button"} aria-label={isExpanded ? "Collapse" : "Expand"} onClick={this.toggleExpansion} data-is-focusable={true}>
               <Icon iconName={isExpanded ? 'ChevronUp' : 'ChevronDown'} />
             </ArrowWrapper>
           </TitleBar>

--- a/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
@@ -31,7 +31,12 @@ class GalleryList extends Component<IProps, IState> {
         <FocusZone>
           <TitleBar>
             <Title>{title}</Title>
-            <ArrowWrapper role={"button"} aria-label={isExpanded ? "Collapse" : "Expand"} onClick={this.toggleExpansion} data-is-focusable={true}>
+            <ArrowWrapper
+              role={'button'}
+              aria-label={isExpanded ? 'Collapse' : 'Expand'}
+              onClick={this.toggleExpansion}
+              data-is-focusable={true}
+            >
               <Icon iconName={isExpanded ? 'ChevronUp' : 'ChevronDown'} />
             </ArrowWrapper>
           </TitleBar>

--- a/packages/editor/src/pages/Editor/components/Backstage/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/index.tsx
@@ -177,6 +177,7 @@ export class Backstage extends Component<IProps, IState> {
       {
         'data-testid': 'new',
         key: 'new',
+        ariaLabel: "New snippet",
         label: 'New Snippet',
         icon: 'Add',
         onClick: () => {
@@ -186,6 +187,7 @@ export class Backstage extends Component<IProps, IState> {
       {
         'data-testid': 'my-solutions',
         key: 'my-solutions',
+        ariaLabel: 'My Snippets',
         label: 'My Snippets',
         icon: 'DocumentSet',
         content: (
@@ -203,6 +205,7 @@ export class Backstage extends Component<IProps, IState> {
       {
         'data-testid': 'samples',
         key: 'samples',
+        ariaLabel: 'Samples',
         label: 'Samples',
         icon: 'Dictionary',
         content: (
@@ -215,6 +218,7 @@ export class Backstage extends Component<IProps, IState> {
       {
         'data-testid': 'import',
         key: 'import',
+        ariaLabel: 'Import',
         label: 'Import',
         icon: 'Download',
         content: <ImportSolution importGist={this.props.importGist} />,

--- a/packages/editor/src/pages/Editor/components/Backstage/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/index.tsx
@@ -177,7 +177,7 @@ export class Backstage extends Component<IProps, IState> {
       {
         'data-testid': 'new',
         key: 'new',
-        ariaLabel: "New snippet",
+        ariaLabel: 'New snippet',
         label: 'New Snippet',
         icon: 'Add',
         onClick: () => {

--- a/packages/editor/src/pages/Editor/components/Notifications/Dialog/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Notifications/Dialog/index.tsx
@@ -54,6 +54,7 @@ export class Dialog extends React.Component<IProps> {
               key={button.key}
               data-testid={button.key}
               text={button.text}
+              aria-label={button.text}
               onClick={this.getDispatchFunctionForOnClick(button.action)}
               primary={button.isPrimary}
             />

--- a/packages/editor/src/pages/Editor/store/header/selectors.ts
+++ b/packages/editor/src/pages/Editor/store/header/selectors.ts
@@ -107,6 +107,7 @@ const getRunButton = createSelector(
       return [
         {
           key: 'run',
+          ariaLabel: 'Run',
           text: 'Run',
           iconProps: { iconName: 'Play' },
           ...(getShouldSplitRunButton()
@@ -117,6 +118,7 @@ const getRunButton = createSelector(
                     {
                       key: 'run-in-this-pane',
                       text: 'Run in this pane',
+                      ariaLabel: 'Run in this pane',
                       iconProps: { iconName: 'Play' },
                       actionCreator: isTrusted
                         ? actions.editor.navigateToRun
@@ -125,6 +127,7 @@ const getRunButton = createSelector(
                     {
                       key: 'run-side-by-side',
                       text: 'Run side-by-side',
+                      ariaLabel: 'Run side-by-side',
                       iconProps: { iconName: 'OpenPaneMirrored' },
                       actionCreator: isTrusted
                         ? () =>
@@ -223,6 +226,7 @@ export const getItems = createSelector(
           {
             key: 'delete',
             text: 'Delete',
+            ariaLabel: 'Delete',
             iconProps: { iconName: 'Delete' },
             iconOnly,
             actionCreator: () =>
@@ -248,6 +252,7 @@ export const getItems = createSelector(
           {
             key: 'share',
             text: 'Share',
+            ariaLabel: 'Share',
             iconProps: { iconName: 'Share' },
             iconOnly,
             subMenuProps: {
@@ -259,6 +264,7 @@ export const getItems = createSelector(
                     isLoggedIn
                   ),
                   key: 'update-gist',
+                  ariaLabel: 'Update existing gist',
                   text: 'Update existing gist',
                   iconProps: { iconName: 'Save' },
                   actionCreator: () => actions.gists.update.request({ solutionId }),
@@ -266,6 +272,7 @@ export const getItems = createSelector(
                 {
                   key: 'new-public-gist',
                   text: 'New public gist',
+                  ariaLabel: 'New public gist',
                   iconProps: { iconName: 'PageCheckedIn' },
                   actionCreator: isLoggedIn
                     ? () => actions.gists.create.request({ solutionId, isPublic: true })
@@ -274,6 +281,7 @@ export const getItems = createSelector(
                 {
                   key: 'new-secret-gist',
                   text: 'New secret gist',
+                  ariaLabel: 'New secret gist',
                   iconProps: { iconName: 'ProtectedDocument' },
                   actionCreator: isLoggedIn
                     ? () => actions.gists.create.request({ solutionId, isPublic: false })
@@ -282,6 +290,7 @@ export const getItems = createSelector(
                 {
                   key: 'export-to-clipboard',
                   text: 'Copy to clipboard',
+                  ariaLabel: 'Copy to clipboard',
                   iconProps: { iconName: 'ClipboardSolid' },
                   className: 'export-snippet-to-clipboard',
                 },

--- a/packages/runner/src/pages/Runner/components/App/Header.tsx
+++ b/packages/runner/src/pages/Runner/components/App/Header.tsx
@@ -18,11 +18,13 @@ const Header = ({ solution, goBack, refresh, hardRefresh, openCode }: IProps) =>
     {
       hidden: !goBack,
       key: 'go-back',
+      'aria-label': 'Back',
       iconProps: { iconName: 'Back' },
       onClick: goBack,
     },
     {
       key: 'title',
+      'aria-label': solution ? `Refresh ${solution.name}` : '',
       text: solution ? solution.name : '',
       onRenderIcon: () => {
         return solution === undefined ? (
@@ -39,11 +41,13 @@ const Header = ({ solution, goBack, refresh, hardRefresh, openCode }: IProps) =>
   const farItems = [
     {
       key: 'overflow',
+      'aria-label': 'More options',
       iconProps: { iconName: 'More' },
       subMenuProps: {
         items: [
           {
             key: 'hard-refresh',
+            'aria-label': 'Hard Refresh',
             iconProps: { iconName: 'Refresh' },
             text: 'Hard Refresh',
             onClick: hardRefresh,
@@ -51,6 +55,7 @@ const Header = ({ solution, goBack, refresh, hardRefresh, openCode }: IProps) =>
           shouldShowPopoutControl('runner')
             ? {
                 key: 'pop-out',
+                'aria-label': 'Open Code Editor',
                 iconProps: { iconName: 'OpenInNewWindow' },
                 text: 'Open Code Editor',
                 onClick: openCode,


### PR DESCRIPTION
This PR adds missing aria labels to the main controls for both the editor and the runner. 
This addresses bug #s: 2908112, 2963099, 3010982, and 3012957