### PR TITLE
Jiju/customfunction

### DIFF
--- a/packages/editor/src/pages/CustomFunctions/components/App/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/components/App/index.tsx
@@ -78,7 +78,7 @@ const AppHOC = (UI: React.ComponentType<IPropsToUI>) =>
           await registerCustomFunctions(
             this.state.customFunctionsSummaryItems,
             this.state.customFunctionsCode,
-            registrationResult.options
+            registrationResult.options,
           );
         }
 
@@ -149,7 +149,11 @@ function getCustomFunctionsSolutions(): ISolution[] {
 
 async function getRegistrationResult(
   cfSolutions: ISolution[],
-): Promise<{ parseResults: Array<ICustomFunctionParseResult<IFunction>>; code: string; options?: object }> {
+): Promise<{
+  parseResults: Array<ICustomFunctionParseResult<IFunction>>;
+  code: string;
+  options?: object;
+}> {
   const pythonCFs = cfSolutions
     .map(solution => ({ solution, script: findScript(solution) }))
     .filter(({ script }) => script.language === 'python')
@@ -172,8 +176,8 @@ async function getRegistrationResultPython(
   if (!config) {
     throw new ScriptLabError(
       `To support Python custom functions, you must ` +
-      `enter the required settings in the editor's "Settings" page. ` +
-      `Please close this pane, add the necessary settings, and try again.`,
+        `enter the required settings in the editor's "Settings" page. ` +
+        `Please close this pane, add the necessary settings, and try again.`,
       null,
       { hideCloseButton: true },
     );
@@ -187,7 +191,7 @@ async function getRegistrationResultPython(
   );
   showSplashScreen(
     `Attempting to connect to your Jupyter notebook, to allow execution ` +
-    `of Python custom functions. Please wait...`,
+      `of Python custom functions. Please wait...`,
   );
 
   try {
@@ -220,7 +224,7 @@ async function getRegistrationResultPython(
     invokeGlobalErrorHandler(
       new ScriptLabError(
         'Could not connect to Jupyter notebook. ' +
-        `Please ensure that you've entered the correct Jupyter settings and that Jupyter is running`,
+          `Please ensure that you've entered the correct Jupyter settings and that Jupyter is running`,
         e,
       ),
     );

--- a/packages/editor/src/pages/CustomFunctions/components/App/utilities/index.ts
+++ b/packages/editor/src/pages/CustomFunctions/components/App/utilities/index.ts
@@ -13,7 +13,8 @@ import {
 } from '../../../../../utils/custom-functions';
 
 export function getJsonMetadataString(
-  functions: Array<ICustomFunctionParseResult<IFunction>>, options?: object
+  functions: Array<ICustomFunctionParseResult<IFunction>>,
+  options?: object,
 ): string {
   const registrationPayload: ICustomFunctionsMetadata = {
     functions: functions
@@ -21,8 +22,12 @@ export function getJsonMetadataString(
       .map(func => func.metadata),
   };
 
-  if (options instanceof Object && options["allowCustomDataForDataTypeAny"] !== undefined) {
-    registrationPayload["allowCustomDataForDataTypeAny"] = options["allowCustomDataForDataTypeAny"];
+  if (
+    options instanceof Object &&
+    options['allowCustomDataForDataTypeAny'] !== undefined
+  ) {
+    registrationPayload['allowCustomDataForDataTypeAny'] =
+      options['allowCustomDataForDataTypeAny'];
   }
 
   return JSON.stringify(registrationPayload, null, 4);
@@ -31,7 +36,7 @@ export function getJsonMetadataString(
 export async function registerCustomFunctions(
   functions: Array<ICustomFunctionParseResult<IFunction>>,
   code: string,
-  options: object
+  options: object,
 ): Promise<void> {
   const jsonMetadataString = getJsonMetadataString(functions, options);
 
@@ -137,7 +142,11 @@ export function getScriptLabTopLevelNamespace() {
 
 export function getCustomFunctionsInfoForRegistration(
   solutions: ISolution[],
-): { parseResults: Array<ICustomFunctionParseResult<IFunction>>; code: string; options: object } {
+): {
+  parseResults: Array<ICustomFunctionParseResult<IFunction>>;
+  code: string;
+  options: object;
+} {
   const parseResults: Array<ICustomFunctionParseResult<IFunction>> = [];
   const code: string[] = [decodeURIComponent(consoleMonkeypatch.trim())];
 
@@ -190,8 +199,8 @@ export function getCustomFunctionsInfoForRegistration(
   });
 
   const options = {
-    allowCustomDataForDataTypeAny: getAllowCustomDataForDataTypeAny()
-  }
+    allowCustomDataForDataTypeAny: getAllowCustomDataForDataTypeAny(),
+  };
 
   return { parseResults: parseResults, code: code.join('\n\n'), options: options };
 }
@@ -213,9 +222,9 @@ function wrapCustomFunctionSnippetCode(
       try {
         // TODO external code
         ${code
-      .split('\n')
-      .map(line => newlineAndIndents + line)
-      .join('')}
+          .split('\n')
+          .map(line => newlineAndIndents + line)
+          .join('')}
         ${generateFunctionAssignments(true /*success*/)}
       } catch (e) {
         ${generateFunctionAssignments(false /*success*/)}

--- a/packages/editor/src/pages/CustomFunctions/components/Metadata/index.tsx
+++ b/packages/editor/src/pages/CustomFunctions/components/Metadata/index.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { getJsonMetadataString } from '../App/utilities';
-import {
-  getAllowCustomDataForDataTypeAny,
-} from '../../../../utils/custom-functions';
+import { getAllowCustomDataForDataTypeAny } from '../../../../utils/custom-functions';
 export interface IProps {
   items: Array<ICustomFunctionParseResult<null>> | null;
 }
@@ -17,7 +15,7 @@ export const Metadata = ({ items }: IProps) => (
     resizable={false}
     multiline
     value={getJsonMetadataString(items, {
-      allowCustomDataForDataTypeAny: getAllowCustomDataForDataTypeAny()
+      allowCustomDataForDataTypeAny: getAllowCustomDataForDataTypeAny(),
     })}
     style={{ fontFamily: 'Consolas, monaco, monospace' }}
     styles={{

--- a/packages/editor/src/pages/Editor/store/settings/utilities.ts
+++ b/packages/editor/src/pages/Editor/store/settings/utilities.ts
@@ -72,34 +72,34 @@ const getSettingsFiles = (
   timestamp: number,
   userSettings: Partial<ISettings>,
 ): IFile[] => [
-    {
-      id: USER_SETTINGS_FILE_ID,
-      name: 'User Settings',
-      dateCreated: timestamp,
-      dateLastModified: timestamp,
-      dateLastOpened: timestamp,
-      language: SETTINGS_JSON_LANGUAGE,
-      content: getUserSettingsContent(userSettings),
-    },
-    {
-      id: DEFAULT_SETTINGS_FILE_ID,
-      name: 'Default Settings',
-      dateCreated: timestamp,
-      dateLastModified: timestamp,
-      dateLastOpened: timestamp,
-      language: SETTINGS_JSON_LANGUAGE,
-      content: getDefaultSettingsContent(userSettings),
-    },
-    {
-      id: ABOUT_FILE_ID,
-      name: 'About',
-      dateCreated: timestamp,
-      dateLastModified: timestamp,
-      dateLastOpened: timestamp,
-      language: 'plaintext',
-      content: getAboutContent(),
-    },
-  ];
+  {
+    id: USER_SETTINGS_FILE_ID,
+    name: 'User Settings',
+    dateCreated: timestamp,
+    dateLastModified: timestamp,
+    dateLastOpened: timestamp,
+    language: SETTINGS_JSON_LANGUAGE,
+    content: getUserSettingsContent(userSettings),
+  },
+  {
+    id: DEFAULT_SETTINGS_FILE_ID,
+    name: 'Default Settings',
+    dateCreated: timestamp,
+    dateLastModified: timestamp,
+    dateLastOpened: timestamp,
+    language: SETTINGS_JSON_LANGUAGE,
+    content: getDefaultSettingsContent(userSettings),
+  },
+  {
+    id: ABOUT_FILE_ID,
+    name: 'About',
+    dateCreated: timestamp,
+    dateLastModified: timestamp,
+    dateLastOpened: timestamp,
+    language: 'plaintext',
+    content: getAboutContent(),
+  },
+];
 
 const getSettingsSolution = (
   files: IFile[],

--- a/packages/editor/src/utils/custom-functions/index.ts
+++ b/packages/editor/src/utils/custom-functions/index.ts
@@ -137,8 +137,8 @@ export function parseMetadata({
         extras.errors.length > 0
           ? 'error'
           : solution.options.isUntrusted
-            ? 'untrusted'
-            : 'good',
+          ? 'untrusted'
+          : 'good',
       errors: [
         ...(solution.options.isUntrusted
           ? ['You must trust the snippet before its functions can be registered']


### PR DESCRIPTION
This PR is about to add a setting to script lab to support the Custom Function support custom data feature in excel

When users put "allowCustomDataForDataTypeAny": true in the setting page, it will enable custom function to accept custom data(yellow data) as parameters, so the code of custom function can deal with custom data type.

Details: when "allowCustomDataForDataTypeAny" exist in user settings, it will add the value to metadata.json of custom function.
