### PR TITLE
Add more ariaLabels!

### DIFF
--- a/packages/common/src/components/PivotBar/index.tsx
+++ b/packages/common/src/components/PivotBar/index.tsx
@@ -10,6 +10,7 @@ import { PivotBarWrapper } from './styles';
 
 export interface IPivotBarItem {
   key: string;
+  ariaLabel?: string;
   text?: string;
   iconName?: string;
   testId?: string;
@@ -83,6 +84,7 @@ class PivotBar extends React.Component<IProps> {
               itemIcon={item.iconName}
               data-testid={item.testId}
               itemCount={item.itemCount || undefined}
+              ariaLabel={item.ariaLabel}
             />
           ))}
         </Pivot>

--- a/packages/editor/src/pages/Editor/components/Backstage/Menu/PivotMenu.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/Menu/PivotMenu.tsx
@@ -37,6 +37,7 @@ class PivotMenu extends React.Component<IProps> {
                 return {
                   text: label,
                   key,
+                  ariaLabel,
                 };
               }
             })}

--- a/packages/editor/src/pages/Editor/store/footer/selectors.ts
+++ b/packages/editor/src/pages/Editor/store/footer/selectors.ts
@@ -120,7 +120,7 @@ export const getFarItems = createSelector(
       key: 'cycle-theme',
       iconProps: { iconName: 'Color', styles: { root: { fontSize: '1.2rem' } } },
       text: currentEditorTheme,
-      ariaLabel: 'Cycle editor theme',
+      ariaLabel: `Cycle editor theme, ${currentEditorTheme} theme selected`,
       actionCreator: actions.settings.cycleEditorTheme,
     },
     {


### PR DESCRIPTION
This PR addresses bugs: #5547205 and #5543890 by adding several missing aria labels to the pivot menu items, and adding the needed info to the editor theme selector aria label. 