### PR TITLE
improve show-hide button aria label

### DIFF
--- a/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
@@ -33,7 +33,7 @@ class GalleryList extends Component<IProps, IState> {
             <Title>{title}</Title>
             <ArrowWrapper
               role={'button'}
-              aria-label={title + " section " + (isExpanded ? 'Hide' : 'Show')}
+              aria-label={title + ' section ' + (isExpanded ? 'Hide' : 'Show')}
               onClick={this.toggleExpansion}
               data-is-focusable={true}
             >

--- a/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
@@ -33,7 +33,7 @@ class GalleryList extends Component<IProps, IState> {
             <Title>{title}</Title>
             <ArrowWrapper
               role={'button'}
-              aria-label={isExpanded ? 'Collapse' : 'Expand'}
+              aria-label={title + " section " + (isExpanded ? 'Hide' : 'Show')}
               onClick={this.toggleExpansion}
               data-is-focusable={true}
             >


### PR DESCRIPTION
Improve the expand/collapse aria labels in the Samples sections so that Narrator will read something like "Basics section hide, button", rather than "Collapse, button".