### PR TITLE
Move server auth use built in node https

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.16.0",
+    "@types/node": "16.*",
     "nodemon": "^1.18.3",
     "ts-loader": "^5.2.0",
     "tslint": "^5.11.0",

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -90,7 +90,7 @@ function getResultObjectBasedOnAuthResponse(
 export async function getAccessTokenOrErrorResponse(
   input: IServerAuthRequest,
 ): Promise<IServerAuthResponse> {
-  console.log('post');
+  //console.log('post');
 
   const { status, buffer } = await github_auth_post(input.code, input.state);
   // console.log(status)

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -14,13 +14,13 @@ async function github_auth_post(code: string, state: string) {
 
   const options = {
     host: 'github.com',
-    method: "POST",
-    path: "/login/oauth/access_token",
+    method: 'POST',
+    path: '/login/oauth/access_token',
     headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    }
-  }
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  };
 
   const post_data = {
     client_id: GITHUB_CLIENT_ID,
@@ -31,20 +31,17 @@ async function github_auth_post(code: string, state: string) {
   };
   const data = JSON.stringify(post_data);
 
-
   // Good to know what is actually being sent
   // console.log(options)
   // console.log(data)
 
   return new Promise<{ status: number; buffer: () => Promise<string> }>(
     (resolve, reject) => {
-
-
       const request = https.request(options, (response: any) => {
         const statusCode = response.statusCode;
         response.setEncoding('utf8');
 
-        response.on("error", (err: any) => {
+        response.on('error', (err: any) => {
           reject(err);
         });
 
@@ -55,8 +52,8 @@ async function github_auth_post(code: string, state: string) {
           data += chunk;
         });
 
-        const dataBuffer = new Promise<string>((resolveBuffer) => {
-          response.on("end", () => {
+        const dataBuffer = new Promise<string>(resolveBuffer => {
+          response.on('end', () => {
             resolveBuffer(data);
           });
         });
@@ -69,12 +66,12 @@ async function github_auth_post(code: string, state: string) {
 
       request.on('error', (e: any) => {
         //console.log("Error : " + e.message);
-        reject(e)
+        reject(e);
       });
 
       request.write(data);
       request.end();
-    }
+    },
   );
 }
 
@@ -93,7 +90,7 @@ function getResultObjectBasedOnAuthResponse(
 export async function getAccessTokenOrErrorResponse(
   input: IServerAuthRequest,
 ): Promise<IServerAuthResponse> {
-  console.log("post");
+  console.log('post');
 
   const { status, buffer } = await github_auth_post(input.code, input.state);
   // console.log(status)

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -22,14 +22,14 @@ async function github_auth_post(code: string, state: string) {
     },
   };
 
-  const post_data = {
+  const postData = {
     client_id: GITHUB_CLIENT_ID,
     client_secret: GITHUB_CLIENT_SECRET,
     redirect_uri: GITHUB_REDIRECT_URL,
     code,
     state,
   };
-  const data = JSON.stringify(post_data);
+  const data = JSON.stringify(postData);
 
   // Good to know what is actually being sent
   // console.log(options)
@@ -90,7 +90,7 @@ function getResultObjectBasedOnAuthResponse(
 export async function getAccessTokenOrErrorResponse(
   input: IServerAuthRequest,
 ): Promise<IServerAuthResponse> {
-  //console.log('post');
+
 
   const { status, buffer } = await github_auth_post(input.code, input.state);
   // console.log(status)

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -90,8 +90,6 @@ function getResultObjectBasedOnAuthResponse(
 export async function getAccessTokenOrErrorResponse(
   input: IServerAuthRequest,
 ): Promise<IServerAuthResponse> {
-
-
   const { status, buffer } = await github_auth_post(input.code, input.state);
   // console.log(status)
   if (status !== 200) {

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,62 +1,109 @@
 const { GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, GITHUB_REDIRECT_URL } = process.env;
 const GENERIC_ERROR_STRING = 'An unexpected login error has occurred.';
 
-export interface IGithubApiAccessTokenResponse {
+export interface GithubApiAccessTokenResponse {
   access_token: string;
   error: string;
   error_description: string;
 }
 
-export function getAccessTokenOrErrorResponse(
-  input: IServerAuthRequest,
-): Promise<IServerAuthResponse> {
-  let postRequest = new Promise((resolve, reject) => {
-    const url = 'https://github.com/login/oauth/access_token';
-    const data = {
-      client_id: GITHUB_CLIENT_ID,
-      client_secret: GITHUB_CLIENT_SECRET,
-      redirect_uri: GITHUB_REDIRECT_URL,
-      code: input.code,
-      state: input.state,
-    };
+const https = require('https');
 
-    let request = new XMLHttpRequest();
+async function github_auth_post(code: string, state: string) {
+  // https://github.com/login/oauth/access_token
 
-    request.addEventListener('readystatechange', () => {
-      if (request.readyState === 4 && request.status === 200) {
-        let responseData: IGithubApiAccessTokenResponse = JSON.parse(
-          request.responseText,
-        );
-        resolve(responseData);
-      } else if (request.readyState === 4) {
-        reject('Failure retrieving data');
-      }
-    });
-
-    request.open('POST', url);
-    request.setRequestHeader('Accept', 'application/json');
-    request.send(data);
-  });
-  return postRequest
-    .then(response => {
-      return getResultObjectBasedOnAuthResponse(
-        response as IGithubApiAccessTokenResponse,
-      );
-    })
-    .catch(() => {
-      return { error: GENERIC_ERROR_STRING };
-    });
-
-  // Helper
-  function getResultObjectBasedOnAuthResponse(
-    body: IGithubApiAccessTokenResponse,
-  ): IServerAuthResponse {
-    if (body.error) {
-      return { error: body.error + ': ' + body.error_description };
-    } else if (body.access_token) {
-      return { access_token: body.access_token };
-    } else {
-      return { error: GENERIC_ERROR_STRING };
+  const options = {
+    host: 'github.com',
+    method: "POST",
+    path: "/login/oauth/access_token",
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
     }
   }
+
+  const post_data = {
+    client_id: GITHUB_CLIENT_ID,
+    client_secret: GITHUB_CLIENT_SECRET,
+    redirect_uri: GITHUB_REDIRECT_URL,
+    code,
+    state,
+  };
+  const data = JSON.stringify(post_data);
+
+
+  // Good to know what is actually being sent
+  // console.log(options)
+  // console.log(data)
+
+  return new Promise<{ status: number; buffer: () => Promise<string> }>(
+    (resolve, reject) => {
+
+
+      const request = https.request(options, (response: any) => {
+        const statusCode = response.statusCode;
+        response.setEncoding('utf8');
+
+        response.on("error", (err: any) => {
+          reject(err);
+        });
+
+        // collect the data
+        let data = '';
+
+        response.on('data', (chunk: string) => {
+          data += chunk;
+        });
+
+        const dataBuffer = new Promise<string>((resolveBuffer) => {
+          response.on("end", () => {
+            resolveBuffer(data);
+          });
+        });
+
+        resolve({
+          status: statusCode || -1,
+          buffer: () => dataBuffer,
+        });
+      });
+
+      request.on('error', (e: any) => {
+        //console.log("Error : " + e.message);
+        reject(e)
+      });
+
+      request.write(data);
+      request.end();
+    }
+  );
+}
+
+function getResultObjectBasedOnAuthResponse(
+  body: GithubApiAccessTokenResponse,
+): IServerAuthResponse {
+  if (body.error) {
+    return { error: body.error + ': ' + body.error_description };
+  } else if (body.access_token) {
+    return { access_token: body.access_token };
+  } else {
+    return { error: GENERIC_ERROR_STRING };
+  }
+}
+
+export async function getAccessTokenOrErrorResponse(
+  input: IServerAuthRequest,
+): Promise<IServerAuthResponse> {
+  console.log("post");
+
+  const { status, buffer } = await github_auth_post(input.code, input.state);
+  // console.log(status)
+  if (status !== 200) {
+    return { error: GENERIC_ERROR_STRING };
+  }
+
+  const response = await buffer();
+  // console.log(response);
+  const data = JSON.parse(response) as GithubApiAccessTokenResponse;
+  const result = getResultObjectBasedOnAuthResponse(data);
+  return result;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.36.tgz#5637905dbb15c30a33a3c65b9ef7c20e3c85ebad"
   integrity sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==
 
+"@types/node@16.*":
+  version "16.18.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.12.tgz#e3bfea80e31523fde4292a6118f19ffa24fd6f65"
+  integrity sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==
+
 "@types/node@^10.0.9", "@types/node@^10.9.4":
   version "10.17.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.55.tgz#a147f282edec679b894d4694edb5abeb595fecbd"


### PR DESCRIPTION
## background

Removing unnecessary dependencies

The server directory runs on a node express server

## notes
- XMLHttpRequest does not exist in node. Instead using https. (fetch would be easier but that requires node 18, which might not be available on the server)

## testing
- Verified using localhost