### PR TITLE
add tab index to force edge to not skip

### DIFF
--- a/packages/runner/src/pages/Runner/components/SnippetContainer/IFrame/index.tsx
+++ b/packages/runner/src/pages/Runner/components/SnippetContainer/IFrame/index.tsx
@@ -110,7 +110,7 @@ class IFrame extends React.Component<IProps, IState> {
       <iframe
         title="user-snippet"
         id="user-snippet"
-        tabindex="0"
+        tabIndex={0}
         ref={node => (this.node = node)}
         style={{
           width: '100%',

--- a/packages/runner/src/pages/Runner/components/SnippetContainer/IFrame/index.tsx
+++ b/packages/runner/src/pages/Runner/components/SnippetContainer/IFrame/index.tsx
@@ -110,6 +110,7 @@ class IFrame extends React.Component<IProps, IState> {
       <iframe
         title="user-snippet"
         id="user-snippet"
+        tabindex="0"
         ref={node => (this.node = node)}
         style={{
           width: '100%',


### PR DESCRIPTION
# Description:
- This PR adds a tabIndex on the iframe to force edge to not skip the runner content