### PR TITLE
Add item index to aria-label in gallery list

### DIFF
--- a/packages/editor/src/pages/Editor/components/Backstage/GalleryList/GalleryListItem/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/GalleryList/GalleryListItem/index.tsx
@@ -11,13 +11,19 @@ export interface IGalleryListItem {
   index: number;
 }
 
-const GalleryListItem = ({ title, description, isActive, onClick, index }: IGalleryListItem) => {
+const GalleryListItem = ({
+  title,
+  description,
+  isActive,
+  onClick,
+  index,
+}: IGalleryListItem) => {
   const ItemWrapper = isActive ? ActiveWrapper : Wrapper;
   return (
     <ItemWrapper
       data-is-focusable="true"
       onClick={onClick}
-      aria-label={index + ". " + title}
+      aria-label={index + '. ' + title}
       id={composeSolutionId(title)}
     >
       <Title>{title}</Title>

--- a/packages/editor/src/pages/Editor/components/Backstage/GalleryList/GalleryListItem/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/GalleryList/GalleryListItem/index.tsx
@@ -8,15 +8,16 @@ export interface IGalleryListItem {
   description?: string;
   isActive?: boolean;
   onClick?: () => void;
+  index: number;
 }
 
-const GalleryListItem = ({ title, description, isActive, onClick }: IGalleryListItem) => {
+const GalleryListItem = ({ title, description, isActive, onClick, index }: IGalleryListItem) => {
   const ItemWrapper = isActive ? ActiveWrapper : Wrapper;
   return (
     <ItemWrapper
       data-is-focusable="true"
       onClick={onClick}
-      aria-label={title}
+      aria-label={index + ". " + title}
       id={composeSolutionId(title)}
     >
       <Title>{title}</Title>

--- a/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/GalleryList/index.tsx
@@ -43,8 +43,8 @@ class GalleryList extends Component<IProps, IState> {
           <Only when={messageBar !== undefined}>{messageBar}</Only>
           <Only when={isExpanded}>
             <div data-testid={testId}>
-              {items.map(item => (
-                <GalleryListItem key={item.key} {...item} />
+              {items.map((item, index) => (
+                <GalleryListItem key={item.key} index={index} {...item} />
               ))}
             </div>
           </Only>

--- a/packages/editor/src/pages/Editor/components/Backstage/MySolutions/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/MySolutions/index.tsx
@@ -113,9 +113,10 @@ class MySolutions extends React.Component<IProps> {
                 solution.description,
               ]),
             )
-            .map(sol => ({
+            .map((sol, index) => ({
               key: sol.id,
               title: sol.name,
+              index: index,
               description: sol.description,
               onClick: () => openSolution(sol.id),
               isActive: activeSolution && activeSolution.id === sol.id,
@@ -137,11 +138,12 @@ class MySolutions extends React.Component<IProps> {
                   meta.description,
                 ]),
               )
-              .map(gist => ({
+              .map((gist, index) => ({
                 key: gist.id,
                 title: gist.title,
                 description: gist.description,
                 onClick: () => openGist(gist),
+                index: index,
               }))}
           />
         )}

--- a/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
+++ b/packages/editor/src/pages/Editor/components/Backstage/Samples/index.tsx
@@ -84,11 +84,12 @@ class Samples extends Component<IProps, IState> {
                     key={group}
                     title={group}
                     items={filteredSamplesByGroup[group].map(
-                      ({ id, name, description, rawUrl }) => ({
+                      ({ id, name, description, rawUrl }, index) => ({
                         key: id,
                         title: name,
                         description,
                         onClick: () => openSample(rawUrl),
+                        index: index,
                       }),
                     )}
                   />


### PR DESCRIPTION
This change improves accessibility by prepending an index number to each snippet/sample in the gallery list.