### PR TITLE
Update manifest to support recent Outlook features

### DIFF
--- a/manifests/script-lab-react-localhost.outlook.xml
+++ b/manifests/script-lab-react-localhost.outlook.xml
@@ -166,7 +166,7 @@
     <Hosts>
       <Host xsi:type="MailHost">
         <DesktopFormFactor>
-	<SupportsSharedFolders>true</SupportsSharedFolders>
+          <SupportsSharedFolders>true</SupportsSharedFolders>
           <FunctionFile resid="PG.Functions.Url" />
           <ExtensionPoint xsi:type="MessageComposeCommandSurface">
             <OfficeTab id="TabPlaygroundCompose">
@@ -201,6 +201,8 @@
                   <Action xsi:type="ShowTaskpane">
                     <SourceLocation resid="PG.Run.Url" />
                     <SupportsPinning>true</SupportsPinning>
+                    <SupportsNoItemContext>true</SupportsNoItemContext>
+                    <SupportsMultiSelect>true</SupportsMultiSelect>
                   </Action>
                 </Control>
                 <Control xsi:type="Button" id="PG.TutorialCommand.Compose">
@@ -299,6 +301,8 @@
                   <Action xsi:type="ShowTaskpane">
                     <SourceLocation resid="PG.Run.Url" />
                     <SupportsPinning>true</SupportsPinning>
+                    <SupportsNoItemContext>true</SupportsNoItemContext>
+                    <SupportsMultiSelect>true</SupportsMultiSelect>
                   </Action>
                 </Control>
                 <Control xsi:type="Button" id="PG.TutorialCommand.Read">
@@ -397,6 +401,8 @@
                   <Action xsi:type="ShowTaskpane">
                     <SourceLocation resid="PG.Run.Url" />
                     <SupportsPinning>true</SupportsPinning>
+                    <SupportsNoItemContext>true</SupportsNoItemContext>
+                    <SupportsMultiSelect>true</SupportsMultiSelect>
                   </Action>
                 </Control>
                 <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentAttendee">
@@ -495,6 +501,8 @@
                   <Action xsi:type="ShowTaskpane">
                     <SourceLocation resid="PG.Run.Url" />
                     <SupportsPinning>true</SupportsPinning>
+                    <SupportsNoItemContext>true</SupportsNoItemContext>
+                    <SupportsMultiSelect>true</SupportsMultiSelect>
                   </Action>
                 </Control>
                 <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentOrganizer">

--- a/manifests/sideload.outlook.xml
+++ b/manifests/sideload.outlook.xml
@@ -209,6 +209,8 @@
                     <Action xsi:type="ShowTaskpane">
                       <SourceLocation resid="PG.Run.Url" />
                       <SupportsPinning>true</SupportsPinning>
+                      <SupportsNoItemContext>true</SupportsNoItemContext>
+                      <SupportsMultiSelect>true</SupportsMultiSelect>
                     </Action>
                   </Control>
                   <Control xsi:type="Button" id="PG.TutorialCommand.Compose">
@@ -307,6 +309,8 @@
                     <Action xsi:type="ShowTaskpane">
                       <SourceLocation resid="PG.Run.Url" />
                       <SupportsPinning>true</SupportsPinning>
+                      <SupportsNoItemContext>true</SupportsNoItemContext>
+                      <SupportsMultiSelect>true</SupportsMultiSelect>
                     </Action>
                   </Control>
                   <Control xsi:type="Button" id="PG.TutorialCommand.Read">
@@ -405,6 +409,8 @@
                     <Action xsi:type="ShowTaskpane">
                       <SourceLocation resid="PG.Run.Url" />
                       <SupportsPinning>true</SupportsPinning>
+                      <SupportsNoItemContext>true</SupportsNoItemContext>
+                      <SupportsMultiSelect>true</SupportsMultiSelect>
                     </Action>
                   </Control>
                   <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentAttendee">
@@ -503,6 +509,8 @@
                     <Action xsi:type="ShowTaskpane">
                       <SourceLocation resid="PG.Run.Url" />
                       <SupportsPinning>true</SupportsPinning>
+                      <SupportsNoItemContext>true</SupportsNoItemContext>
+                      <SupportsMultiSelect>true</SupportsMultiSelect>
                     </Action>
                   </Control>
                   <Control xsi:type="Button" id="PG.TutorialCommand.AppointmentOrganizer">


### PR DESCRIPTION
Adds the [SupportsNoItemContext](https://learn.microsoft.com/javascript/api/manifest/action#supportsnoitemcontext) and [SupportsMultiSelect](https://learn.microsoft.com/javascript/api/manifest/action#supportsmultiselect) elements to the Outlook manifests.